### PR TITLE
Make db-seed script cross-platform compatibile

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "db-seed": "NODE_ENV=development prisma db seed"
+    "db-seed": "cross-env NODE_ENV=development prisma db seed"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -76,6 +76,7 @@
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
     "autoprefixer": "^10.4.15",
+    "cross-env": "^7.0.3",
     "eslint": "^8.47.0",
     "eslint-config-next": "^13.4.13",
     "eslint-config-prettier": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ devDependencies:
   autoprefixer:
     specifier: ^10.4.15
     version: 10.4.15(postcss@8.4.27)
+  cross-env:
+    specifier: ^7.0.3
+    version: 7.0.3
   eslint:
     specifier: ^8.47.0
     version: 8.47.0
@@ -6445,6 +6448,14 @@ packages:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.11
+    dev: true
+
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
     dev: true
 
   /cross-spawn@7.0.3:


### PR DESCRIPTION
`"db-seed": "NODE_ENV=development prisma db seed"` does not work on windows because windows requires using SET in the command to set environment variables inline. 

`cross-env` solves this by allowing for setting and using environment variables inline across platforms. 