### PR TITLE
Fix/ protocol upload compatibility issues

### DIFF
--- a/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
+++ b/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
@@ -41,7 +41,7 @@ import { trpc } from '~/app/_trpc/client';
 export default function ProtocolUploader({
   onUploaded,
 }: {
-  onUploaded: () => void;
+  onUploaded?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [showErrorDetails, setShowErrorDetails] = useState(false);
@@ -100,7 +100,6 @@ export default function ProtocolUploader({
       progress: false,
       error: '',
     });
-    onUploaded();
   };
 
   const { startUpload } = useUploadThing({
@@ -166,6 +165,9 @@ export default function ProtocolUploader({
 
   function onSubmit(data: z.infer<typeof ActivateProtocolFormSchema>) {
     setActive({ setActive: data.mark_protocol_active });
+    if (typeof onUploaded === 'function') {
+      onUploaded();
+    }
   }
 
   return (


### PR DESCRIPTION
- https://github.com/complexdatacollective/Fresco/pull/15 implemented optionally marking protocols as 'active' after uploaded.
-  https://github.com/complexdatacollective/Fresco/pull/14 implemented working onboarding protocol upload flow

This PR makes those compatible with one another by:

- Making onUploaded optional so that it does not need to be used in standard protocol upload, just to determine onboarding step
- if onUploaded is passed to ProtocolUploader, waiting to call it until "finish import" is clicked. This fixes issue where user was not prompted to optionally activate protocol on upload in the onboarding flow because the step continued as soon as the protocol was successfully uploaded. 

