### PR TITLE
Feature/plausible

### DIFF
--- a/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
+++ b/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
@@ -40,6 +40,8 @@ export default function ProtocolUploader({
 
   const utils = api.useUtils();
 
+  const appSettings = api.appSettings.get.useQuery();
+
   const handleUploadComplete = async (
     res: UploadFileResponse[] | undefined,
   ) => {
@@ -70,7 +72,7 @@ export default function ProtocolUploader({
     await utils.protocol.get.lastUploaded.refetch();
     plausible('ProtocolImported', {
       props: {
-        installationID: '123',
+        installationID: appSettings?.data?.installationId,
       },
     });
 

--- a/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
+++ b/app/(dashboard)/dashboard/_components/ProtocolUploader.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { FileWithPath } from 'react-dropzone';
 import { generateReactHelpers } from '@uploadthing/react/hooks';
 import { useState, useCallback } from 'react';
+import { usePlausible } from 'next-plausible';
 
 import { importProtocol } from '../_actions/importProtocol';
 import { Button } from '~/components/ui/Button';
@@ -35,6 +36,7 @@ export default function ProtocolUploader({
     progress: true,
     error: 'dsfsdf',
   });
+  const plausible = usePlausible();
 
   const utils = api.useUtils();
 
@@ -66,6 +68,11 @@ export default function ProtocolUploader({
     }
 
     await utils.protocol.get.lastUploaded.refetch();
+    plausible('ProtocolImported', {
+      props: {
+        installationID: '123',
+      },
+    });
 
     setDialogContent({
       title: 'Protocol import',

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import ResetButton from './_components/ResetButton';
 import AnonymousRecruitmentSwitch from '~/components/AnonymousRecruitmentSwitch/AnonymousRecruitmentSwitch';
 import Link from 'next/link';
 import { Button } from '~/components/ui/Button';
+import AnalyticsSwitch from '~/components/AnalyticsSwitch/AnalyticsSwitch';
 
 function Home() {
   return (
@@ -14,6 +15,7 @@ function Home() {
         </Link>
         <ResetButton />
         <AnonymousRecruitmentSwitch />
+        <AnalyticsSwitch />
       </main>
     </>
   );

--- a/app/(onboard)/_components/OnboardSteps/Analytics.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Analytics.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { Button } from '~/components/ui/Button';
+import { useOnboardingContext } from '../OnboardingProvider';
+
+function Analytics() {
+  const { currentStep, setCurrentStep } = useOnboardingContext();
+
+  const handleNextStep = () => {
+    setCurrentStep(currentStep + 1).catch(() => {});
+  };
+
+  return (
+    <div className="max-w-[30rem]">
+      <div className="mb-4 flex flex-col">
+        <h1 className="text-3xl font-bold">Analytics</h1>
+        <p className="mb-4 mt-4">
+          By default, the app is configured to allow collection of analytics.
+          This includes number of protocols uploaded, number of interviews
+          conducted, and number of interviews completed. No personally
+          identifiable information, interview data, or protocol data is
+          collected. Analytics collection can be disabled from the dashboard.
+        </p>
+      </div>
+      <div>
+        <div className="flex justify-start">
+          <Button onClick={handleNextStep}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Analytics;

--- a/app/(onboard)/_components/OnboardSteps/Analytics.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Analytics.tsx
@@ -2,6 +2,7 @@
 import { Button } from '~/components/ui/Button';
 import { useOnboardingContext } from '../OnboardingProvider';
 import AnalyticsSwitch from '~/components/AnalyticsSwitch/Switch';
+import { api } from '~/trpc/client';
 
 function Analytics() {
   const { currentStep, setCurrentStep } = useOnboardingContext();
@@ -10,6 +11,11 @@ function Analytics() {
     setCurrentStep(currentStep + 1).catch(() => {});
   };
 
+  const appSettings = api.appSettings.get.useQuery(undefined, {
+    onError(error) {
+      throw new Error(error.message);
+    },
+  });
   return (
     <div className="max-w-[30rem]">
       <div className="mb-4 flex flex-col">
@@ -21,7 +27,7 @@ function Analytics() {
         </p>
       </div>
       <div>
-        <AnalyticsSwitch allowAnalytics={true} />
+        <AnalyticsSwitch allowAnalytics={!!appSettings?.data?.allowAnalytics} />
         <div className="flex justify-start">
           <Button onClick={handleNextStep}>Next</Button>
         </div>

--- a/app/(onboard)/_components/OnboardSteps/Analytics.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Analytics.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Button } from '~/components/ui/Button';
 import { useOnboardingContext } from '../OnboardingProvider';
+import AnalyticsSwitch from '~/components/AnalyticsSwitch/Switch';
 
 function Analytics() {
   const { currentStep, setCurrentStep } = useOnboardingContext();
@@ -15,13 +16,12 @@ function Analytics() {
         <h1 className="text-3xl font-bold">Analytics</h1>
         <p className="mb-4 mt-4">
           By default, the app is configured to allow collection of analytics.
-          This includes number of protocols uploaded, number of interviews
-          conducted, and number of interviews completed. No personally
-          identifiable information, interview data, or protocol data is
-          collected. Analytics collection can be disabled from the dashboard.
+          Analytics collection can be disabled here or in the app settings on
+          the dashboard.
         </p>
       </div>
       <div>
+        <AnalyticsSwitch allowAnalytics={true} />
         <div className="flex justify-start">
           <Button onClick={handleNextStep}>Next</Button>
         </div>

--- a/app/(onboard)/_components/OnboardSteps/Documentation.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Documentation.tsx
@@ -57,12 +57,10 @@ function Documentation() {
       </Card>
 
       <div className="flex justify-start pt-12">
-        <form>
-          <button onClick={handleAppConfigured}>
-            <SubmitButton variant="default" size={'lg'}>
-              Go to the dashboard!
-            </SubmitButton>
-          </button>
+        <form action={handleAppConfigured}>
+          <SubmitButton variant="default" size={'lg'}>
+            Go to the dashboard!
+          </SubmitButton>
         </form>
       </div>
     </div>

--- a/app/(onboard)/_components/OnboardSteps/Documentation.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Documentation.tsx
@@ -3,14 +3,20 @@ import { FileText, MonitorPlay } from 'lucide-react';
 import { setAppConfigured } from '~/app/_actions';
 import SubmitButton from '~/components/ui/SubmitButton';
 import { usePlausible } from 'next-plausible';
+import { api } from '~/trpc/client';
 
 function Documentation() {
+  const appSettings = api.appSettings.get.useQuery();
+
   const plausible = usePlausible();
   const handleAppConfigured = async () => {
     await setAppConfigured();
 
-    plausible('AppSetup', { props: { installationID: '123' } });
+    plausible('AppSetup', {
+      props: { installationID: appSettings?.data?.installationId },
+    });
   };
+
   return (
     <div className="max-w-[30rem]">
       <div className="mb-4 flex flex-col">

--- a/app/(onboard)/_components/OnboardSteps/Documentation.tsx
+++ b/app/(onboard)/_components/OnboardSteps/Documentation.tsx
@@ -2,8 +2,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { FileText, MonitorPlay } from 'lucide-react';
 import { setAppConfigured } from '~/app/_actions';
 import SubmitButton from '~/components/ui/SubmitButton';
+import { usePlausible } from 'next-plausible';
 
 function Documentation() {
+  const plausible = usePlausible();
+  const handleAppConfigured = async () => {
+    await setAppConfigured();
+
+    plausible('AppSetup', { props: { installationID: '123' } });
+  };
   return (
     <div className="max-w-[30rem]">
       <div className="mb-4 flex flex-col">
@@ -44,10 +51,12 @@ function Documentation() {
       </Card>
 
       <div className="flex justify-start pt-12">
-        <form action={setAppConfigured}>
-          <SubmitButton variant="default" size={'lg'}>
-            Go to the dashboard!
-          </SubmitButton>
+        <form>
+          <button onClick={handleAppConfigured}>
+            <SubmitButton variant="default" size={'lg'}>
+              Go to the dashboard!
+            </SubmitButton>
+          </button>
         </form>
       </div>
     </div>

--- a/app/(onboard)/_components/Sidebar.tsx
+++ b/app/(onboard)/_components/Sidebar.tsx
@@ -8,6 +8,7 @@ const stepLabels = [
   'Create Account',
   'Upload Protocol',
   'Configure Participation',
+  'Analytics',
   'Documentation',
 ];
 

--- a/app/(onboard)/setup/page.tsx
+++ b/app/(onboard)/setup/page.tsx
@@ -34,6 +34,12 @@ const ManageParticipants = dynamic(
     loading: () => <StepLoadingState key="loading" />,
   },
 );
+const Analytics = dynamic(
+  () => import('../_components/OnboardSteps/Analytics'),
+  {
+    loading: () => <StepLoadingState key="loading" />,
+  },
+);
 const Documentation = dynamic(
   () => import('../_components/OnboardSteps/Documentation'),
   {
@@ -104,6 +110,11 @@ function Page() {
               </StepMotionWrapper>
             )}
             {currentStep === 4 && (
+              <StepMotionWrapper key="docs">
+                <Analytics />
+              </StepMotionWrapper>
+            )}
+            {currentStep === 5 && (
               <StepMotionWrapper key="docs">
                 <Documentation />
               </StepMotionWrapper>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,7 @@ async function RootLayout({ children }: { children: React.ReactNode }) {
           trackLocalhost={true}
           enabled={true}
           taggedEvents={true}
+          manualPageviews={true}
         />
       </head>
       <body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,8 +30,6 @@ async function RootLayout({ children }: { children: React.ReactNode }) {
     <html lang="en">
       <head>
         <PlausibleProvider
-          // this is the domain of the site you want to track
-          // TODO: figure out how to track all instances of fresco
           domain="fresco.networkcanvas.com"
           trackLocalhost={true}
           enabled={true}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { getServerSession } from '~/utils/auth';
 import { api } from '~/trpc/server';
 import { Toaster } from '~/components/ui/toaster';
 import { revalidatePath, revalidateTag } from 'next/cache';
+import PlausibleProvider from 'next-plausible';
 
 export const metadata = {
   title: 'Network Canvas Fresco',
@@ -27,6 +28,16 @@ async function RootLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <html lang="en">
+      <head>
+        <PlausibleProvider
+          // this is the domain of the site you want to track
+          // TODO: figure out how to track all instances of fresco
+          domain="fresco.networkcanvas.com"
+          trackLocalhost={true}
+          enabled={true}
+          taggedEvents={true}
+        />
+      </head>
       <body>
         <RedirectWrapper
           configured={!!appSettings?.configured}

--- a/components/AnalyticsSwitch/AnalyticsSwitch.tsx
+++ b/components/AnalyticsSwitch/AnalyticsSwitch.tsx
@@ -1,0 +1,11 @@
+import { api } from '~/trpc/server';
+import Switch from './Switch';
+import 'server-only';
+
+const AnalyticsSwitch = async () => {
+  const appSettings = await api.appSettings.get.query();
+
+  return <Switch allowAnalytics={!!appSettings?.allowAnalytics} />;
+};
+
+export default AnalyticsSwitch;

--- a/components/AnalyticsSwitch/Switch.tsx
+++ b/components/AnalyticsSwitch/Switch.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Switch as SwitchUI } from '~/components/ui/switch';
+import { setAnalytics } from './action';
+import { useOptimistic, useTransition } from 'react';
+
+const Switch = ({ allowAnalytics }: { allowAnalytics: boolean }) => {
+  const [, startTransition] = useTransition();
+  const [optimisticAllowAnalytics, setOptimisticAllowAnalytics] = useOptimistic(
+    allowAnalytics,
+    (state: boolean, newState: boolean) => newState,
+  );
+
+  return (
+    <div className="mb-4">
+      <div className="flex items-center justify-between">
+        <div className="mr-20">
+          <h3 className="font-bold">Allow Analytics Reporting</h3>
+          <p className="text-sm text-gray-600">
+            Information collected includes: number of protocols uploaded, number
+            of interviews conducted, number of participants recruited, and
+            number of participants who completed the interview. No personally
+            identifiable information, interview data, or protocol data is
+            collected.
+          </p>
+        </div>
+        <SwitchUI
+          name="allowAnalytics"
+          checked={optimisticAllowAnalytics}
+          onCheckedChange={(value) => {
+            startTransition(async () => {
+              setOptimisticAllowAnalytics(value);
+              await setAnalytics(value);
+            });
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Switch;

--- a/components/AnalyticsSwitch/Switch.tsx
+++ b/components/AnalyticsSwitch/Switch.tsx
@@ -15,13 +15,12 @@ const Switch = ({ allowAnalytics }: { allowAnalytics: boolean }) => {
     <div className="mb-4">
       <div className="flex items-center justify-between">
         <div className="mr-20">
-          <h3 className="font-bold">Allow Analytics Reporting</h3>
+          <h3 className="font-bold">Allow Analytics</h3>
           <p className="text-sm text-gray-600">
-            Information collected includes: number of protocols uploaded, number
-            of interviews conducted, number of participants recruited, and
-            number of participants who completed the interview. No personally
-            identifiable information, interview data, or protocol data is
-            collected.
+            Information collected includes the number of protocols uploaded,
+            interviews conducted, participants recruited, and participants who
+            completed the interview. No personally identifiable information,
+            interview data, or protocol data is collected.
           </p>
         </div>
         <SwitchUI

--- a/components/AnalyticsSwitch/action.ts
+++ b/components/AnalyticsSwitch/action.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { api } from '~/trpc/server';
+
+export async function setAnalytics(state: boolean) {
+  await api.appSettings.updateAnalytics.mutate(state);
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lucia": "^2.7.2",
     "lucide-react": "^0.286.0",
     "next": "^14.0.0",
+    "next-plausible": "^3.11.3",
     "next-usequerystate": "^1.8.4",
     "papaparse": "^5.4.1",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ dependencies:
   next:
     specifier: ^14.0.0
     version: 14.0.0(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.4)
+  next-plausible:
+    specifier: ^3.11.3
+    version: 3.11.3(next@14.0.0)(react-dom@18.2.0)(react@18.2.0)
   next-usequerystate:
     specifier: ^1.8.4
     version: 1.8.4(next@14.0.0)
@@ -10353,6 +10356,18 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
+
+  /next-plausible@3.11.3(next@14.0.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2dpG58ryxdsr4ZI8whWQpGv0T6foRDPGiehcICpDhYfmMJmluewswQgfDA8Z37RFMXAY+6SHOPS7Xi+9ewNi2Q==}
+    peerDependencies:
+      next: ^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      next: 14.0.0(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.4)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /next-usequerystate@1.8.4(next@14.0.0):
     resolution: {integrity: sha512-V4xMh87cu950Zy1Jpw/H8GwWxAeAmqnLNJ8hAl5bdEWpyZV4UIKdkJePKMCUy1+h254EXGmY83BuCGJOASJRVg==}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,5 @@ model AppSettings {
   initializedAt             DateTime @default(now())
   allowAnonymousRecruitment Boolean  @default(false)
   installationId            String   @unique @default(cuid())
-
-  @@id([configured, initializedAt])
+  allowAnalytics            Boolean  @default(true)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model AppSettings {
   configured                Boolean  @default(false)
   initializedAt             DateTime @default(now())
   allowAnonymousRecruitment Boolean  @default(false)
+  installationId            String   @unique @default(cuid())
 
   @@id([configured, initializedAt])
 }

--- a/server/routers/appSettings.ts
+++ b/server/routers/appSettings.ts
@@ -59,6 +59,23 @@ export const appSettingsRouter = router({
         return { error: 'Failed to update appSettings', appSettings: null };
       }
     }),
+  updateAnalytics: protectedProcedure
+    .input(z.boolean())
+    .mutation(async ({ input }) => {
+      try {
+        const updatedappSettings = await prisma.appSettings.updateMany({
+          data: {
+            allowAnalytics: input,
+          },
+        });
+
+        revalidateTag('appSettings.get');
+
+        return { error: null, appSettings: updatedappSettings };
+      } catch (error) {
+        return { error: 'Failed to update appSettings', appSettings: null };
+      }
+    }),
 
   reset: devProcedure.mutation(async ({ ctx }) => {
     const userID = ctx.session?.user.userId;


### PR DESCRIPTION
This PR implements the necessary changes in Fresco to allow it to connect to Plausible. This is tested in a free trial of the managed version of Plausible, but should also be compatible with our self hosted version. 

- Uses the package next-plausible and its PlausibleProvider to connect the app to Plausible
- Demonstration of triggering custom goals AppSetup and ProtocolImported
- Attaches the installationId (which replaced the joint key for AppSettings) each time a goal is triggered so that goals can be managed by installation
- Allows the user to disable sending analytics from the onboarding steps and dashboard