### PR TITLE
Bug Fix: Proper handling of empty assets in `deleteProtocols`

### DIFF
--- a/server/routers/protocol.ts
+++ b/server/routers/protocol.ts
@@ -36,12 +36,6 @@ export const deleteProtocols = async (hashes: string[]) => {
       select: { key: true },
     });
 
-    if (assets.length === 0) {
-      // eslint-disable-next-line no-console
-      console.log('No assets to delete');
-      return;
-    }
-
     await deleteFilesFromUploadThing(assets.map((a) => a.key));
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -66,13 +60,19 @@ export const deleteProtocols = async (hashes: string[]) => {
 export const deleteFilesFromUploadThing = async (
   fileKey: string | string[],
 ) => {
+  if (fileKey.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('No assets to delete');
+    return;
+  }
+
   const response = await utapi.deleteFiles(fileKey);
 
   if (!response.success) {
     throw new Error('Failed to delete files from uploadthing');
   }
 
-  return response;
+  return;
 };
 
 export const protocolRouter = router({


### PR DESCRIPTION
This PR fixes a bug in the `deleteProtocols` function. Previously, if there were no assets to delete, the function stopped execution in the first `try/catch` block with `return`. Now, with the fix, we check the case of no assets in the `deleteFilesFromUploadThing` function, and if true we stop the execution of code to delete assets from Uploadthing.