### PR TITLE
Bug Fix: Updating Asset model schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Protocol {
 }
 
 model Asset {
-  key        String   @id @unique
+  key        String   @id
   assetId    String   @unique
   name       String
   type       String


### PR DESCRIPTION
This PR fixes the `Invalid prisma.protocol.create() invocation` error by removing `@unique` from the `key` field of the Asset model.

Note: Prisma doesn't allow using `@id` and `@unique` on the same field
Issue here: https://github.com/prisma/prisma/issues/3236