### PR TITLE
Feature/end session functionality

### DIFF
--- a/app/(interview)/interview/[interviewId]/page.tsx
+++ b/app/(interview)/interview/[interviewId]/page.tsx
@@ -1,27 +1,11 @@
 import NoSSRWrapper from '~/utils/NoSSRWrapper';
 import InterviewShell from '../_components/InterviewShell';
-import { api } from '~/trpc/server';
-import { redirect } from 'next/navigation';
 
-export default async function Page({
-  params,
-}: {
-  params: { interviewId: string };
-}) {
+export default function Page({ params }: { params: { interviewId: string } }) {
   const { interviewId } = params;
 
   if (!interviewId) {
     return 'No interview id found';
-  }
-
-  // check if interview is finished
-  const interview = await api.interview.get.byId.query({ id: interviewId });
-  if (!interview) {
-    return 'Interview not found';
-  }
-
-  if (interview.finishTime) {
-    redirect('/interview/finished');
   }
 
   return (

--- a/app/(interview)/interview/[interviewId]/page.tsx
+++ b/app/(interview)/interview/[interviewId]/page.tsx
@@ -1,11 +1,27 @@
 import NoSSRWrapper from '~/utils/NoSSRWrapper';
 import InterviewShell from '../_components/InterviewShell';
+import { api } from '~/trpc/server';
+import { redirect } from 'next/navigation';
 
-export default function Page({ params }: { params: { interviewId: string } }) {
+export default async function Page({
+  params,
+}: {
+  params: { interviewId: string };
+}) {
   const { interviewId } = params;
 
   if (!interviewId) {
     return 'No interview id found';
+  }
+
+  // check if interview is finished
+  const interview = await api.interview.get.byId.query({ id: interviewId });
+  if (!interview) {
+    return 'Interview not found';
+  }
+
+  if (interview.finishTime) {
+    redirect('/interview/finished');
   }
 
   return (

--- a/app/(interview)/interview/_components/FinishInterviewModal.tsx
+++ b/app/(interview)/interview/_components/FinishInterviewModal.tsx
@@ -22,7 +22,6 @@ type FinishInterviewModalProps = {
 const FinishInterviewModal = ({ open, setOpen }: FinishInterviewModalProps) => {
   const router = useRouter();
   const pathname = usePathname();
-  const utils = api.useUtils();
 
   const interviewId = pathname.split('/').pop();
   const { mutateAsync: finishInterview } = api.interview.finish.useMutation({
@@ -31,8 +30,7 @@ const FinishInterviewModal = ({ open, setOpen }: FinishInterviewModalProps) => {
     },
     async onSuccess() {
       await clientRevalidateTag('interview.get.byId');
-      await utils.interview.get.invalidate();
-      await utils.interview.get.byId.refetch();
+
       router.push('/interview/finished');
     },
   });

--- a/app/(interview)/interview/_components/FinishInterviewModal.tsx
+++ b/app/(interview)/interview/_components/FinishInterviewModal.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '~/components/ui/AlertDialog';
+import { useRouter } from 'next/navigation';
 
 type FinishInterviewModalProps = {
   open: boolean;
@@ -16,8 +17,10 @@ type FinishInterviewModalProps = {
 };
 
 const FinishInterviewModal = ({ open, setOpen }: FinishInterviewModalProps) => {
+  const router = useRouter();
   const handleFinishInterview = () => {
     // redirect to thank you for participating page
+    router.push('/interview/finished');
     // mark session as finished by updating finishedAt
   };
   return (

--- a/app/(interview)/interview/_components/FinishInterviewModal.tsx
+++ b/app/(interview)/interview/_components/FinishInterviewModal.tsx
@@ -1,0 +1,55 @@
+import { type Dispatch, type SetStateAction } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '~/components/ui/AlertDialog';
+
+type FinishInterviewModalProps = {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const FinishInterviewModal = ({ open, setOpen }: FinishInterviewModalProps) => {
+  const handleFinishInterview = () => {
+    // redirect to thank you for participating page
+    // mark session as finished by updating finishedAt
+  };
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-base">
+            Are you sure you want finish the interview?
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-sm">
+            Your responses cannot be changed after you finish the interview.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            onClick={() => {
+              setOpen(false);
+            }}
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              handleFinishInterview();
+            }}
+          >
+            Finish Interview
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default FinishInterviewModal;

--- a/app/(interview)/interview/_components/InterviewShell.tsx
+++ b/app/(interview)/interview/_components/InterviewShell.tsx
@@ -14,6 +14,7 @@ import {
 import { getActiveSession } from '~/lib/interviewer/selectors/session';
 import { store } from '~/lib/interviewer/store';
 import { api } from '~/trpc/client';
+import { useRouter } from 'next/navigation';
 
 // The job of ServerSync is to listen to actions in the redux store, and to sync
 // data with the server.
@@ -68,6 +69,7 @@ const ServerSync = ({ interviewId }: { interviewId: string }) => {
 // Eventually it will handle syncing this data back.
 const InterviewShell = ({ interviewID }: { interviewID: string }) => {
   const [currentStage, setCurrentStage] = useQueryState('stage');
+  const router = useRouter();
 
   const { isLoading } = api.interview.get.byId.useQuery(
     { id: interviewID },
@@ -78,6 +80,9 @@ const InterviewShell = ({ interviewID }: { interviewID: string }) => {
       onSuccess: async (data) => {
         if (!data) {
           return;
+        }
+        if (data.finishTime) {
+          router.push('/interview/finished');
         }
 
         const { protocol, ...serverSession } = data;

--- a/app/(interview)/interview/finished/page.tsx
+++ b/app/(interview)/interview/finished/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Thank you for participating!</h1>
+    </div>
+  );
+}

--- a/app/(interview)/interview/finished/page.tsx
+++ b/app/(interview)/interview/finished/page.tsx
@@ -3,7 +3,7 @@ import { BadgeCheck } from 'lucide-react';
 export default function InterviewCompleted() {
   return (
     <div className="flex h-screen flex-col items-center justify-center bg-[var(--nc-background)]">
-      <BadgeCheck className="mb-4 h-12 w-12 text-white" />
+      <BadgeCheck className="mb-4 h-12 w-12 text-[var(--color-sea-green)]" />
       <h1 className="text-3xl font-extrabold text-white">
         Thank you for participating!
       </h1>

--- a/app/(interview)/interview/finished/page.tsx
+++ b/app/(interview)/interview/finished/page.tsx
@@ -1,7 +1,15 @@
-export default function Page() {
+import { BadgeCheck } from 'lucide-react';
+
+export default function InterviewCompleted() {
   return (
-    <div>
-      <h1>Thank you for participating!</h1>
+    <div className="flex h-screen flex-col items-center justify-center bg-gray-100">
+      <BadgeCheck className="mb-4 h-12 w-12 text-violet-600" />
+      <h1 className="text-3xl font-extrabold text-violet-700">
+        Thank you for participating!
+      </h1>
+      <p className="text-lg text-gray-700">
+        Your interview has been successfully completed.
+      </p>
     </div>
   );
 }

--- a/app/(interview)/interview/finished/page.tsx
+++ b/app/(interview)/interview/finished/page.tsx
@@ -2,12 +2,12 @@ import { BadgeCheck } from 'lucide-react';
 
 export default function InterviewCompleted() {
   return (
-    <div className="flex h-screen flex-col items-center justify-center bg-gray-100">
-      <BadgeCheck className="mb-4 h-12 w-12 text-violet-600" />
-      <h1 className="text-3xl font-extrabold text-violet-700">
+    <div className="flex h-screen flex-col items-center justify-center bg-[var(--nc-background)]">
+      <BadgeCheck className="mb-4 h-12 w-12 text-white" />
+      <h1 className="text-3xl font-extrabold text-white">
         Thank you for participating!
       </h1>
-      <p className="text-lg text-gray-700">
+      <p className="text-lg text-white">
         Your interview has been successfully completed.
       </p>
     </div>

--- a/lib/interviewer/containers/Interfaces/FinishSession.js
+++ b/lib/interviewer/containers/Interfaces/FinishSession.js
@@ -1,16 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Button } from '~/lib/ui/components';
+import Button from '~/lib/ui/components/Button';
+import FinishInterviewModal from '~/app/(interview)/interview/_components/FinishInterviewModal';
 
-const FinishSession = ({ endSession }) => {
+const FinishSession = () => {
   const dispatch = useDispatch();
-  const handleFinishSession = () => {
-    // eslint-disable-next-line no-console
-    console.log(
-      'handleFinishSession /lib/interviewer/containers/Interfaces/FinishSession.js',
-    );
-    // endSession(false, true);
-  };
+  const [openFinishInterviewModal, setOpenFinishInterviewModal] =
+    useState(false);
 
   useEffect(() => {
     dispatch({ type: 'PLAY_SOUND', sound: 'finishSession' });
@@ -18,6 +14,10 @@ const FinishSession = ({ endSession }) => {
 
   return (
     <div className="interface finish-session-interface">
+      <FinishInterviewModal
+        open={openFinishInterviewModal}
+        setOpen={setOpenFinishInterviewModal}
+      />
       <div className="finish-session-interface__frame">
         <h1 className="finish-session-interface__title type--title-1">
           Finish Interview
@@ -30,7 +30,9 @@ const FinishSession = ({ endSession }) => {
         </div>
 
         <div className="finish-session-interface__section finish-session-interface__section--buttons">
-          <Button onClick={handleFinishSession}>Finish</Button>
+          <Button onClick={() => setOpenFinishInterviewModal(true)}>
+            Finish
+          </Button>
         </div>
       </div>
     </div>

--- a/lib/interviewer/containers/Interfaces/FinishSession.js
+++ b/lib/interviewer/containers/Interfaces/FinishSession.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { Button } from '~/lib/ui/components';
 
 const FinishSession = ({ endSession }) => {
   const dispatch = useDispatch();
@@ -13,7 +14,7 @@ const FinishSession = ({ endSession }) => {
 
   useEffect(() => {
     dispatch({ type: 'PLAY_SOUND', sound: 'finishSession' });
-  }, []);
+  }, [dispatch]);
 
   return (
     <div className="interface finish-session-interface">
@@ -26,6 +27,10 @@ const FinishSession = ({ endSession }) => {
             You have reached the end of the interview. If you are satisfied with
             the information you have entered, you may finish the interview now.
           </p>
+        </div>
+
+        <div className="finish-session-interface__section finish-session-interface__section--buttons">
+          <Button onClick={handleFinishSession}>Finish</Button>
         </div>
       </div>
     </div>

--- a/lib/ui/components/Button.js
+++ b/lib/ui/components/Button.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 
 const renderButtonIcon = ({ icon, iconPosition }) => {
   const iconClassNames = cx({
-    button__icon: true,
+    'button__icon': true,
     'button__icon--right': iconPosition === 'right',
   });
 
@@ -15,10 +15,7 @@ const renderButtonIcon = ({ icon, iconPosition }) => {
       const Icon = require('./Icon').default;
       iconElement = <Icon name={icon} className={iconClassNames} />;
     } else {
-      iconElement = React.cloneElement(
-        icon,
-        { className: iconClassNames },
-      );
+      iconElement = React.cloneElement(icon, { className: iconClassNames });
     }
   }
   return iconElement;
@@ -40,7 +37,7 @@ class Button extends PureComponent {
     } = this.props;
 
     const buttonClassNames = cx({
-      button: true,
+      'button': true,
       [`button--${color}`]: !!color,
       [`button--${size}`]: !!size,
       'button--has-icon': !!icon,
@@ -52,37 +49,32 @@ class Button extends PureComponent {
         // eslint-disable-next-line react/button-has-type
         type={type}
         className={buttonClassNames}
-        onClick={onClick?.()}
+        onClick={onClick}
         disabled={disabled}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}
       >
         {renderButtonIcon({ icon, iconPosition })}
-        {(content || children) && <span className="button__content">{children || content}</span>}
+        {(content || children) && (
+          <span className="button__content">{children || content}</span>
+        )}
       </button>
     );
   }
 }
 
 Button.propTypes = {
-  content: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element,
-  ]),
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   children: PropTypes.node,
   icon: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element,
     PropTypes.object,
   ]),
-  iconPosition: PropTypes.oneOf([
-    'left', 'right',
-  ]),
+  iconPosition: PropTypes.oneOf(['left', 'right']),
   size: PropTypes.string,
   color: PropTypes.string,
-  type: PropTypes.oneOf([
-    'button', 'submit', 'reset',
-  ]),
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
 };

--- a/server/routers/interview.ts
+++ b/server/routers/interview.ts
@@ -114,6 +114,28 @@ export const interviewRouter = router({
         return interview;
       }),
   }),
+  finish: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+      }),
+    )
+    .mutation(async ({ input: { id } }) => {
+      try {
+        const updatedInterview = await prisma.interview.update({
+          where: {
+            id,
+          },
+          data: {
+            finishTime: new Date(),
+          },
+        });
+
+        return { error: null, interview: updatedInterview };
+      } catch (error) {
+        return { error: 'Failed to update interview', interview: null };
+      }
+    }),
   delete: protectedProcedure
     .input(
       z.array(


### PR DESCRIPTION
Implements functionality after participant clicks "finish" on the finish interview screen:


- Shows a dialog asking them to confirm, because their responses won't be able to be changed once they continue.
- If they continue, redirects to a thank you for participating page (`/interview/finished`), and update `finishedAt`
- Implements a check in the interview route for if the interview is finished, which if true redirects to the thank you page.