### PR TITLE
implement registerBeforeNext and onComplete functionalities

### DIFF
--- a/lib/interviewer/containers/ProtocolScreen.js
+++ b/lib/interviewer/containers/ProtocolScreen.js
@@ -1,20 +1,58 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Stage from './Stage';
 import { AnimatePresence, motion } from 'framer-motion';
 import { getCurrentStage } from '../selectors/session';
 import { useSelector } from 'react-redux';
 import Navigation from '../components/Navigation';
 
-const registerBeforeNext = () => {
-  // console.log('TODO: implement registerBeforeNext lib/interviewer/containers/ProtocolScreen.js');
-};
-
-const onComplete = () => {
-  // console.log('TODO: implement onComplete lib/interviewer/containers/ProtocolScreen.js');
-};
-
-const ProtocolScreen = () => {
+const ProtocolScreen = (props) => {
   const currentStage = useSelector(getCurrentStage);
+  const [beforeNextFunctions, setBeforeNextFunctions] = useState({});
+  const [pendingStage, setPendingStage] = useState(-1);
+  const [pendingDirection, setPendingDirection] = useState(1);
+
+  const onComplete = (directionOverride) => {
+    const { goToNext } = props;
+    const nextDirection = directionOverride || pendingDirection;
+
+    const navigate =
+      pendingStage === -1
+        ? () => goToNext(nextDirection)
+        : () => goToStage(pendingStage);
+
+    setPendingStage(-1);
+    setPendingDirection(1);
+    navigate();
+  };
+
+  const registerBeforeNext = (beforeNext, stageId) => {
+    if (beforeNext === null) return;
+
+    setBeforeNextFunctions((prevFunctions) => ({
+      ...prevFunctions,
+      [stageId]: beforeNext,
+    }));
+  };
+
+  const goToStage = (index) => {
+    const { isSkipped, openDialog, goToStage } = props;
+    if (isSkipped(index)) {
+      openDialog({
+        type: 'Warning',
+        title: 'Show this stage?',
+        confirmLabel: 'Show Stage',
+        onConfirm: () => goToStage(index),
+        message: (
+          <p>
+            Your skip logic settings would normally prevent this stage from
+            being shown in this interview. Do you want to show it anyway?
+          </p>
+        ),
+      });
+    } else {
+      goToStage(index);
+    }
+  };
 
   if (!currentStage) {
     return null;


### PR DESCRIPTION
This PR implements `registerBeforeNext` and `onComplete` functions that allow a stage to register a function that blocks session navigation.

This is still in progress as I'm not sure how to use the stored `beforeNext` functions to block session navigation