### PR TITLE
update makeEventTracker use to pass `enabled` option

### DIFF
--- a/analytics/utils.ts
+++ b/analytics/utils.ts
@@ -14,6 +14,4 @@ export const getInstallationId = cache(async () => {
   return appSettings?.installationId ?? 'Unknown';
 });
 
-export const trackEvent = !env.DISABLE_ANALYTICS
-  ? makeEventTracker()
-  : () => null;
+export const trackEvent = makeEventTracker({ enabled: !env.DISABLE_ANALYTICS });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@codaco/analytics": "^3.1.0",
+    "@codaco/analytics": "^4.0.0",
     "@codaco/protocol-validation": "3.0.0-alpha.4",
     "@codaco/shared-consts": "^0.0.2",
     "@headlessui/react": "^1.7.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@codaco/analytics':
-    specifier: ^3.1.0
-    version: 3.1.0(@maxmind/geoip2-node@5.0.0)(next@14.1.0)
+    specifier: ^4.0.0
+    version: 4.0.0(@maxmind/geoip2-node@5.0.0)(next@14.1.0)
   '@codaco/protocol-validation':
     specifier: 3.0.0-alpha.4
     version: 3.0.0-alpha.4(@types/eslint@8.44.6)(eslint-config-prettier@9.0.0)(eslint@8.52.0)
@@ -1806,8 +1806,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codaco/analytics@3.1.0(@maxmind/geoip2-node@5.0.0)(next@14.1.0):
-    resolution: {integrity: sha512-wDGm7nMrDHlJ8inY66+lkK/fzc1kC/LL/drI5d8BXyc9sF7+FzB2iL8w093hNL5sKTOubJWWccKwIaX95EUJYQ==}
+  /@codaco/analytics@4.0.0(@maxmind/geoip2-node@5.0.0)(next@14.1.0):
+    resolution: {integrity: sha512-/QJwnlaO3iZDHw206cB6gxXhQE/stwMYqW6tqotuJMCnMXmOa3CqMtcOac546jMs3U1ISU5qxTrECb/iulyDyg==}
     peerDependencies:
       '@maxmind/geoip2-node': ^5.0.0
       next: 13 || 14


### PR DESCRIPTION
This PR:

- updates `@codaco/analytics` to version: `4.0.0`
- updates the use `makeEventTracker ` to accept `{enabled: !env.DISABLE_ANALYTICS}` because this argument has been made mandatory by the new version of the analytics package