### PR TITLE
Feature/export incomplete interview urls

### DIFF
--- a/app/(dashboard)/dashboard/_components/InterviewsTable/InterviewsTable.tsx
+++ b/app/(dashboard)/dashboard/_components/InterviewsTable/InterviewsTable.tsx
@@ -6,11 +6,11 @@ import { InterviewColumns } from '~/app/(dashboard)/dashboard/_components/Interv
 import { DataTable } from '~/components/DataTable/DataTable';
 import { Button } from '~/components/ui/Button';
 import { api } from '~/trpc/client';
-import { DeleteInterviewsDialog } from '../../interviews/_components/DeleteInterviewsDialog';
-import { ExportInterviewsDialog } from '../../interviews/_components/ExportInterviewsDialog';
+import { DeleteInterviewsDialog } from '~/app/(dashboard)/dashboard/interviews/_components/DeleteInterviewsDialog';
+import { ExportInterviewsDialog } from '~/app/(dashboard)/dashboard/interviews/_components/ExportInterviewsDialog';
 import type { RouterOutputs } from '~/trpc/shared';
 import { HardDriveUpload } from 'lucide-react';
-import { GenerateInterviewURLs } from '../../interviews/_components/ExportInterviewUrlSection';
+import { GenerateInterviewURLs } from '~/app/(dashboard)/dashboard/interviews/_components/ExportInterviewUrlSection';
 
 type Interviews = RouterOutputs['interview']['get']['all'];
 

--- a/app/(dashboard)/dashboard/_components/InterviewsTable/InterviewsTable.tsx
+++ b/app/(dashboard)/dashboard/_components/InterviewsTable/InterviewsTable.tsx
@@ -10,6 +10,7 @@ import { DeleteInterviewsDialog } from '../../interviews/_components/DeleteInter
 import { ExportInterviewsDialog } from '../../interviews/_components/ExportInterviewsDialog';
 import type { RouterOutputs } from '~/trpc/shared';
 import { HardDriveUpload } from 'lucide-react';
+import { GenerateInterviewURLs } from '../../interviews/_components/ExportInterviewUrlSection';
 
 type Interviews = RouterOutputs['interview']['get']['all'];
 
@@ -91,6 +92,7 @@ export const InterviewsTable = ({
               <HardDriveUpload className="mr-2 inline-block h-4 w-4" />
               Export all unexported interviews
             </Button>
+            <GenerateInterviewURLs />
           </>
         }
       />

--- a/app/(dashboard)/dashboard/interviews/_components/ExportCSVInterviewURLs.tsx
+++ b/app/(dashboard)/dashboard/interviews/_components/ExportCSVInterviewURLs.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Download } from 'lucide-react';
+import { unparse } from 'papaparse';
+import { useState } from 'react';
+import { Button } from '~/components/ui/Button';
+import { useToast } from '~/components/ui/use-toast';
+import { useDownload } from '~/hooks/useDownload';
+import { type RouterOutputs, getBaseUrl } from '~/trpc/shared';
+
+function ExportCSVInterviewURLs({
+  protocol,
+  interviews,
+  disabled,
+}: {
+  protocol: RouterOutputs['protocol']['get']['all'][0];
+  interviews: RouterOutputs['interview']['get']['all'];
+  disabled: boolean;
+}) {
+  const download = useDownload();
+  const [isExporting, setIsExporting] = useState(false);
+  const { toast } = useToast();
+
+  const handleExport = () => {
+    try {
+      setIsExporting(true);
+      if (!protocol?.id) return;
+
+      const csvData = interviews.map((interview) => ({
+        participant_id: interview.participantId,
+        identifier: interview.participant.identifier,
+        interview_url: `${getBaseUrl()}/interview/${interview.id}`,
+      }));
+
+      const csv = unparse(csvData, { header: true });
+
+      // Create a download link
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      // trigger the download
+      const protocolNameWithoutExtension = protocol.name.split('.')[0];
+      const fileName = `incomplete_interview_urls_${protocolNameWithoutExtension}.csv`;
+      download(url, fileName);
+      // Clean up the URL object
+      URL.revokeObjectURL(url);
+      toast({
+        description: 'Incomplete intervew URLs CSV exported successfully',
+        variant: 'success',
+        duration: 3000,
+      });
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description:
+          'An error occurred while exporting incomplete interview URLs',
+        variant: 'destructive',
+      });
+      throw new Error(
+        'An error occurred while exporting incomplete interview URLs',
+      );
+    }
+
+    setIsExporting(false);
+  };
+
+  return (
+    <Button
+      disabled={disabled || isExporting}
+      onClick={handleExport}
+      className="w-full"
+    >
+      <Download className="mr-2 h-4 w-4" />
+      {isExporting ? 'Exporting...' : 'Export Incomplete Interview URLs'}
+    </Button>
+  );
+}
+
+export default ExportCSVInterviewURLs;

--- a/app/(dashboard)/dashboard/interviews/_components/ExportInterviewUrlSection.tsx
+++ b/app/(dashboard)/dashboard/interviews/_components/ExportInterviewUrlSection.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+
+import { api } from '~/trpc/client';
+import ExportCSVInterviewURLs from './ExportCSVInterviewURLs';
+import { Skeleton } from '~/components/ui/skeleton';
+import { type RouterOutputs } from '~/trpc/shared';
+import { Button } from '~/components/ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { FileUp } from 'lucide-react';
+
+export const GenerateInterviewURLs = () => {
+  const { data: protocols, isLoading: isLoadingProtocols } =
+    api.protocol.get.all.useQuery();
+
+  const { data: interviews } = api.interview.get.all.useQuery();
+
+  const [interviewsToExport, setInterviewsToExport] = useState<
+    RouterOutputs['interview']['get']['all']
+  >([]);
+
+  const [selectedProtocol, setSelectedProtocol] =
+    useState<RouterOutputs['protocol']['get']['all'][0]>();
+
+  // Only export interviews that are 1. incomplete and 2. belong to the selected protocol
+  useEffect(() => {
+    if (interviews) {
+      setInterviewsToExport(
+        interviews.filter(
+          (interview) =>
+            !interview.finishTime &&
+            selectedProtocol?.id === interview.protocolId,
+        ),
+      );
+    }
+  }, [interviews, selectedProtocol]);
+
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <>
+      <Button onClick={handleOpenChange} variant="outline">
+        <FileUp className="mr-2 inline-block h-4 w-4" />
+        Export Incomplete Interview URLs
+      </Button>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Generate Incomplete Interview URLs</DialogTitle>
+            <DialogDescription>
+              Generate a CSV that contains unique interview URLs for all{' '}
+              <strong>incomplete interviews </strong> by protocol. These URLs
+              can be shared with participants to allow them to finish their
+              interviews.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col items-center justify-end gap-4">
+            {isLoadingProtocols || !protocols ? (
+              <Skeleton className="h-10 w-full rounded-input" />
+            ) : (
+              <Select
+                onValueChange={(value) => {
+                  const protocol = protocols.find(
+                    (protocol) => protocol.id === value,
+                  );
+
+                  setSelectedProtocol(protocol);
+                }}
+                value={selectedProtocol?.id}
+                disabled={isLoadingProtocols}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a Protocol..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {protocols?.map((protocol) => (
+                    <SelectItem key={protocol.id} value={protocol.id}>
+                      {protocol.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+          <DialogFooter>
+            <Button onClick={handleOpenChange} variant="outline">
+              Cancel
+            </Button>
+            <ExportCSVInterviewURLs
+              protocol={selectedProtocol!}
+              interviews={interviewsToExport}
+              disabled={!selectedProtocol}
+            />
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};


### PR DESCRIPTION
Adds in ability to export a CSV with interview links of incomplete interviews per protocol. This could be used to remind participants to complete interviews.

Todo:

- [x] Add participant label to CSV from https://github.com/complexdatacollective/Fresco/pull/79