### PR TITLE
Fix/sociogram dragdrop coords

### DIFF
--- a/lib/interviewer/behaviours/withBounds.js
+++ b/lib/interviewer/behaviours/withBounds.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-find-dom-node */
 
 import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { isEqual } from 'lodash';
 import getAbsoluteBoundingRect from '../utils/getAbsoluteBoundingRect';
 
@@ -18,12 +19,12 @@ export default function withBounds(WrappedComponent) {
 
       this.state = initialState;
       this.lastState = initialState;
-      this.node = React.createRef();
+      this.node = null;
 
       this.observer = new ResizeObserver((entries) => {
         for (let entry of entries) {
-          if (entry.target === this.node.current) {
-            const boundingClientRect = getAbsoluteBoundingRect(this.node.current);
+          if (entry.target === this.node) {
+            const boundingClientRect = getAbsoluteBoundingRect(this.node);
 
             const nextState = {
               width: boundingClientRect.width,
@@ -42,26 +43,11 @@ export default function withBounds(WrappedComponent) {
     }
 
     componentDidMount() {
-      if (!this.node.current) {
-        return;
-      }
-
-      const boundingClientRect = getAbsoluteBoundingRect(this.node.current);
-
-      this.setState({
-        width: boundingClientRect.width,
-        height: boundingClientRect.height,
-        y: boundingClientRect.top,
-        x: boundingClientRect.left,
-      });
-
-      this.observer.observe(this.node.current);
+      this.observer.observe(this.node);
     }
 
     componentWillUnmount() {
-      if (!this.observer || !this.node.current) { return; }
-
-      this.observer.unobserve(this.node.current);
+      this.observer.unobserve(this.node);
       this.observer.disconnect();
     }
 
@@ -70,7 +56,9 @@ export default function withBounds(WrappedComponent) {
         <WrappedComponent
           {...this.props}
           {...this.state}
-          ref={this.node}
+          ref={() => {
+            this.node = findDOMNode(this);
+          }}
         />
       );
     }

--- a/lib/interviewer/behaviours/withBounds.js
+++ b/lib/interviewer/behaviours/withBounds.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-find-dom-node */
 
 import React, { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import { isEqual } from 'lodash';
 import getAbsoluteBoundingRect from '../utils/getAbsoluteBoundingRect';
 
@@ -19,12 +18,12 @@ export default function withBounds(WrappedComponent) {
 
       this.state = initialState;
       this.lastState = initialState;
-      this.node = null;
+      this.node = React.createRef();
 
       this.observer = new ResizeObserver((entries) => {
         for (let entry of entries) {
-          if (entry.target === this.node) {
-            const boundingClientRect = getAbsoluteBoundingRect(this.node);
+          if (entry.target === this.node.current) {
+            const boundingClientRect = getAbsoluteBoundingRect(this.node.current);
 
             const nextState = {
               width: boundingClientRect.width,
@@ -43,11 +42,26 @@ export default function withBounds(WrappedComponent) {
     }
 
     componentDidMount() {
-      this.observer.observe(this.node);
+      if (!this.node.current) {
+        return;
+      }
+
+      const boundingClientRect = getAbsoluteBoundingRect(this.node.current);
+
+      this.setState({
+        width: boundingClientRect.width,
+        height: boundingClientRect.height,
+        y: boundingClientRect.top,
+        x: boundingClientRect.left,
+      });
+
+      this.observer.observe(this.node.current);
     }
 
     componentWillUnmount() {
-      this.observer.unobserve(this.node);
+      if (!this.observer || !this.node.current) { return; }
+
+      this.observer.unobserve(this.node.current);
       this.observer.disconnect();
     }
 
@@ -56,9 +70,7 @@ export default function withBounds(WrappedComponent) {
         <WrappedComponent
           {...this.props}
           {...this.state}
-          ref={() => {
-            this.node = findDOMNode(this);
-          }}
+          ref={this.node}
         />
       );
     }

--- a/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
+++ b/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
@@ -1,10 +1,7 @@
 /* eslint-disable no-param-reassign */
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import {
-  entityPrimaryKeyProperty,
-  entityAttributesProperty,
-} from '@codaco/shared-consts';
+import { entityPrimaryKeyProperty, entityAttributesProperty } from '@codaco/shared-consts';
 import { isEmpty, find } from 'lodash';
 import LayoutContext from '../../contexts/LayoutContext';
 import LayoutNode from './LayoutNode';
@@ -33,9 +30,7 @@ class NodeLayout extends React.Component {
   }
 
   componentDidUpdate() {
-    const {
-      network: { nodes },
-    } = this.context;
+    const { network: { nodes } } = this.context;
 
     if (this.layoutEls.length !== nodes.length) {
       this.createLayoutEls();
@@ -49,14 +44,10 @@ class NodeLayout extends React.Component {
   }
 
   createLayoutEls = () => {
-    const {
-      network: { nodes },
-    } = this.context;
+    const { network: { nodes } } = this.context;
 
     this.layoutEls = nodes.map((_, index) => {
-      if (this.layoutEls[index]) {
-        return this.layoutEls[index];
-      }
+      if (this.layoutEls[index]) { return this.layoutEls[index]; }
 
       const nodeEl = document.createElement('div');
       nodeEl.style.position = 'absolute';
@@ -66,26 +57,26 @@ class NodeLayout extends React.Component {
 
       return nodeEl;
     });
-  };
+  }
 
   update = () => {
-    const { getPosition, screen } = this.context;
+    const {
+      getPosition,
+      screen,
+    } = this.context;
 
     this.layoutEls.forEach((el, index) => {
       const relativePosition = getPosition.current(index);
-      if (!relativePosition || !el) {
-        return;
-      }
+      if (!relativePosition || !el) { return; }
 
-      const screenPosition =
-        screen.current.calculateScreenCoords(relativePosition);
+      const screenPosition = screen.current.calculateScreenCoords(relativePosition);
       el.style.left = `${screenPosition.x}px`;
       el.style.top = `${screenPosition.y}px`;
       el.style.display = 'block';
     });
 
     this.updateRAF = requestAnimationFrame(() => this.update());
-  };
+  }
 
   isLinking = (node) => {
     const { connectFrom } = this.props;
@@ -95,34 +86,28 @@ class NodeLayout extends React.Component {
   isHighlighted = (node) => {
     const { highlightAttribute } = this.props;
     return (
-      !isEmpty(highlightAttribute) &&
-      get(node, [entityAttributesProperty, highlightAttribute], false) === true
+      !isEmpty(highlightAttribute)
+      && get(node, [entityAttributesProperty, highlightAttribute], false) === true
     );
   };
 
   isDisabled = (node) => {
-    const { connectFrom, originRestriction, destinationRestriction } =
-      this.props;
-
     const {
-      network: { nodes },
-    } = this.context;
+      connectFrom,
+      originRestriction,
+      destinationRestriction,
+    } = this.props;
+
+    const { network: { nodes } } = this.context;
 
     // Node is disabled if type is same as originRestriction, unless there is a connectFrom
     // If there is a connectFrom, we need to check other things.
-    if (!connectFrom && originRestriction && node.type === originRestriction) {
-      return true;
-    }
+    if (!connectFrom && originRestriction && node.type === originRestriction) { return true; }
 
     // Not disabled if we aren't linking, or if the node is the origin
-    if (!connectFrom || connectFrom === node[entityPrimaryKeyProperty]) {
-      return false;
-    }
+    if (!connectFrom || connectFrom === node[entityPrimaryKeyProperty]) { return false; }
 
-    const originType = find(nodes, [
-      entityPrimaryKeyProperty,
-      connectFrom,
-    ]).type;
+    const originType = find(nodes, [entityPrimaryKeyProperty, connectFrom]).type;
     const thisType = get(node, 'type');
 
     if (destinationRestriction === 'same') {
@@ -149,7 +134,10 @@ class NodeLayout extends React.Component {
 
     const { updateNode } = this.props;
 
-    const { x, y } = delta;
+    const {
+      x,
+      y,
+    } = delta;
 
     const relativeDelta = screen.current.calculateRelativeCoords(delta);
 
@@ -164,9 +152,11 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(uuid, undefined, {
-      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
-    });
+    updateNode(
+      uuid,
+      undefined,
+      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
+    );
   };
 
   handleDragMove = (uuid, index, delta) => {
@@ -180,7 +170,10 @@ class NodeLayout extends React.Component {
 
     const { updateNode } = this.props;
 
-    const { x, y } = delta;
+    const {
+      x,
+      y,
+    } = delta;
 
     const relativeDelta = screen.current.calculateRelativeCoords(delta);
 
@@ -195,9 +188,11 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(uuid, undefined, {
-      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
-    });
+    updateNode(
+      uuid,
+      undefined,
+      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
+    );
   };
 
   handleDragEnd = (uuid, index, { x, y }) => {
@@ -209,7 +204,9 @@ class NodeLayout extends React.Component {
       screen,
     } = this.context;
 
-    const { updateNode } = this.props;
+    const {
+      updateNode,
+    } = this.props;
 
     if (allowAutomaticLayout) {
       const { simulationEnabled, releaseNode } = simulation;
@@ -223,17 +220,17 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(uuid, undefined, {
-      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
-    });
+    updateNode(
+      uuid,
+      undefined,
+      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
+    );
   };
 
   // When node is dragged this is called last,
   // we can use that to reset isDragging state
   handleSelected = (...args) => {
-    if (this.isDisabled(...args)) {
-      return;
-    }
+    if (this.isDisabled(...args)) { return; }
     const { onSelected } = this.props;
 
     if (this.isDragging) {
@@ -248,16 +245,21 @@ class NodeLayout extends React.Component {
       network: { nodes },
     } = this.context;
 
-    const { allowPositioning, allowSelect } = this.props;
+    const {
+      allowPositioning,
+      allowSelect,
+      innerRef,
+    } = this.props;
 
     return (
       <>
-        <div className="node-layout" ref={this.ref} />
+        <div className="node-layout" ref={node => {
+          this.ref.current = node
+          innerRef.current = node
+        }} />
         {nodes.map((node, index) => {
           const el = this.layoutEls[index];
-          if (!el) {
-            return null;
-          }
+          if (!el) { return null; }
           return (
             <LayoutNode
               node={node}
@@ -294,6 +296,10 @@ NodeLayout.defaultProps = {
 
 NodeLayout.contextType = LayoutContext;
 
-export { NodeLayout };
+const NodeLayoutForwardingRef = forwardRef((props, ref) => (
+  <NodeLayout {...props} innerRef={ref} />
+));
 
-export default NodeLayout;
+NodeLayoutForwardingRef.displayName = 'NodeLayout';
+
+export default NodeLayoutForwardingRef;

--- a/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
+++ b/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
@@ -1,7 +1,10 @@
 /* eslint-disable no-param-reassign */
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { entityPrimaryKeyProperty, entityAttributesProperty } from '@codaco/shared-consts';
+import {
+  entityPrimaryKeyProperty,
+  entityAttributesProperty,
+} from '@codaco/shared-consts';
 import { isEmpty, find } from 'lodash';
 import LayoutContext from '../../contexts/LayoutContext';
 import LayoutNode from './LayoutNode';
@@ -30,7 +33,9 @@ class NodeLayout extends React.Component {
   }
 
   componentDidUpdate() {
-    const { network: { nodes } } = this.context;
+    const {
+      network: { nodes },
+    } = this.context;
 
     if (this.layoutEls.length !== nodes.length) {
       this.createLayoutEls();
@@ -44,10 +49,14 @@ class NodeLayout extends React.Component {
   }
 
   createLayoutEls = () => {
-    const { network: { nodes } } = this.context;
+    const {
+      network: { nodes },
+    } = this.context;
 
     this.layoutEls = nodes.map((_, index) => {
-      if (this.layoutEls[index]) { return this.layoutEls[index]; }
+      if (this.layoutEls[index]) {
+        return this.layoutEls[index];
+      }
 
       const nodeEl = document.createElement('div');
       nodeEl.style.position = 'absolute';
@@ -57,26 +66,26 @@ class NodeLayout extends React.Component {
 
       return nodeEl;
     });
-  }
+  };
 
   update = () => {
-    const {
-      getPosition,
-      screen,
-    } = this.context;
+    const { getPosition, screen } = this.context;
 
     this.layoutEls.forEach((el, index) => {
       const relativePosition = getPosition.current(index);
-      if (!relativePosition || !el) { return; }
+      if (!relativePosition || !el) {
+        return;
+      }
 
-      const screenPosition = screen.current.calculateScreenCoords(relativePosition);
+      const screenPosition =
+        screen.current.calculateScreenCoords(relativePosition);
       el.style.left = `${screenPosition.x}px`;
       el.style.top = `${screenPosition.y}px`;
       el.style.display = 'block';
     });
 
     this.updateRAF = requestAnimationFrame(() => this.update());
-  }
+  };
 
   isLinking = (node) => {
     const { connectFrom } = this.props;
@@ -86,28 +95,34 @@ class NodeLayout extends React.Component {
   isHighlighted = (node) => {
     const { highlightAttribute } = this.props;
     return (
-      !isEmpty(highlightAttribute)
-      && get(node, [entityAttributesProperty, highlightAttribute], false) === true
+      !isEmpty(highlightAttribute) &&
+      get(node, [entityAttributesProperty, highlightAttribute], false) === true
     );
   };
 
   isDisabled = (node) => {
-    const {
-      connectFrom,
-      originRestriction,
-      destinationRestriction,
-    } = this.props;
+    const { connectFrom, originRestriction, destinationRestriction } =
+      this.props;
 
-    const { network: { nodes } } = this.context;
+    const {
+      network: { nodes },
+    } = this.context;
 
     // Node is disabled if type is same as originRestriction, unless there is a connectFrom
     // If there is a connectFrom, we need to check other things.
-    if (!connectFrom && originRestriction && node.type === originRestriction) { return true; }
+    if (!connectFrom && originRestriction && node.type === originRestriction) {
+      return true;
+    }
 
     // Not disabled if we aren't linking, or if the node is the origin
-    if (!connectFrom || connectFrom === node[entityPrimaryKeyProperty]) { return false; }
+    if (!connectFrom || connectFrom === node[entityPrimaryKeyProperty]) {
+      return false;
+    }
 
-    const originType = find(nodes, [entityPrimaryKeyProperty, connectFrom]).type;
+    const originType = find(nodes, [
+      entityPrimaryKeyProperty,
+      connectFrom,
+    ]).type;
     const thisType = get(node, 'type');
 
     if (destinationRestriction === 'same') {
@@ -134,10 +149,7 @@ class NodeLayout extends React.Component {
 
     const { updateNode } = this.props;
 
-    const {
-      x,
-      y,
-    } = delta;
+    const { x, y } = delta;
 
     const relativeDelta = screen.current.calculateRelativeCoords(delta);
 
@@ -152,11 +164,9 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(
-      uuid,
-      undefined,
-      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
-    );
+    updateNode(uuid, undefined, {
+      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
+    });
   };
 
   handleDragMove = (uuid, index, delta) => {
@@ -170,10 +180,7 @@ class NodeLayout extends React.Component {
 
     const { updateNode } = this.props;
 
-    const {
-      x,
-      y,
-    } = delta;
+    const { x, y } = delta;
 
     const relativeDelta = screen.current.calculateRelativeCoords(delta);
 
@@ -188,11 +195,9 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(
-      uuid,
-      undefined,
-      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
-    );
+    updateNode(uuid, undefined, {
+      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
+    });
   };
 
   handleDragEnd = (uuid, index, { x, y }) => {
@@ -204,9 +209,7 @@ class NodeLayout extends React.Component {
       screen,
     } = this.context;
 
-    const {
-      updateNode,
-    } = this.props;
+    const { updateNode } = this.props;
 
     if (allowAutomaticLayout) {
       const { simulationEnabled, releaseNode } = simulation;
@@ -220,17 +223,17 @@ class NodeLayout extends React.Component {
     const nodeType = get(nodes, [index, 'type']);
     const layoutVariable = getTwoModeLayoutVariable(twoMode, nodeType, layout);
 
-    updateNode(
-      uuid,
-      undefined,
-      { [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }) },
-    );
+    updateNode(uuid, undefined, {
+      [layoutVariable]: screen.current.calculateRelativeCoords({ x, y }),
+    });
   };
 
   // When node is dragged this is called last,
   // we can use that to reset isDragging state
   handleSelected = (...args) => {
-    if (this.isDisabled(...args)) { return; }
+    if (this.isDisabled(...args)) {
+      return;
+    }
     const { onSelected } = this.props;
 
     if (this.isDragging) {
@@ -245,21 +248,16 @@ class NodeLayout extends React.Component {
       network: { nodes },
     } = this.context;
 
-    const {
-      allowPositioning,
-      allowSelect,
-      innerRef,
-    } = this.props;
+    const { allowPositioning, allowSelect } = this.props;
 
     return (
       <>
-        <div className="node-layout" ref={node => {
-          this.ref.current = node
-          innerRef.current = node
-        }} />
+        <div className="node-layout" ref={this.ref} />
         {nodes.map((node, index) => {
           const el = this.layoutEls[index];
-          if (!el) { return null; }
+          if (!el) {
+            return null;
+          }
           return (
             <LayoutNode
               node={node}
@@ -296,10 +294,6 @@ NodeLayout.defaultProps = {
 
 NodeLayout.contextType = LayoutContext;
 
-const NodeLayoutForwardingRef = forwardRef((props, ref) => (
-  <NodeLayout {...props} innerRef={ref} />
-));
+export { NodeLayout };
 
-NodeLayoutForwardingRef.displayName = 'NodeLayout';
-
-export default NodeLayoutForwardingRef;
+export default NodeLayout;

--- a/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
+++ b/lib/interviewer/components/RealtimeCanvas/NodeLayout.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { entityPrimaryKeyProperty, entityAttributesProperty } from '@codaco/shared-consts';
 import { isEmpty, find } from 'lodash';
@@ -248,15 +248,11 @@ class NodeLayout extends React.Component {
     const {
       allowPositioning,
       allowSelect,
-      innerRef,
     } = this.props;
 
     return (
       <>
-        <div className="node-layout" ref={node => {
-          this.ref.current = node
-          innerRef.current = node
-        }} />
+        <div className="node-layout" ref={this.ref} />
         {nodes.map((node, index) => {
           const el = this.layoutEls[index];
           if (!el) { return null; }
@@ -296,10 +292,6 @@ NodeLayout.defaultProps = {
 
 NodeLayout.contextType = LayoutContext;
 
-const NodeLayoutForwardingRef = forwardRef((props, ref) => (
-  <NodeLayout {...props} innerRef={ref} />
-));
+export { NodeLayout };
 
-NodeLayoutForwardingRef.displayName = 'NodeLayout';
-
-export default NodeLayoutForwardingRef;
+export default NodeLayout;

--- a/lib/interviewer/containers/Canvas/NodeLayout.js
+++ b/lib/interviewer/containers/Canvas/NodeLayout.js
@@ -1,9 +1,6 @@
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompose';
-import {
-  entityAttributesProperty,
-  entityPrimaryKeyProperty,
-} from '@codaco/shared-consts';
+import { entityAttributesProperty, entityPrimaryKeyProperty } from '@codaco/shared-consts';
 import { actionCreators as sessionsActions } from '../../ducks/modules/session';
 import withBounds from '../../behaviours/withBounds';
 import { store } from '../../store';
@@ -19,127 +16,108 @@ const relativeCoords = (container, node) => ({
 const withConnectFrom = withState('connectFrom', 'setConnectFrom', null);
 
 const withConnectFromHandler = withHandlers({
-  handleConnectFrom:
-    ({ setConnectFrom }) =>
-    (id) => {
-      if (id === null) {
-        store.dispatch({
-          type: 'STOP_SOUND',
-          sound: 'link',
-        });
-      } else {
-        store.dispatch({
-          type: 'PLAY_SOUND',
-          sound: 'link',
-        });
-      }
+  handleConnectFrom: ({ setConnectFrom }) => (id) => {
+    if (id === null) {
+      store.dispatch({
+        type: 'STOP_SOUND',
+        sound: 'link',
+      });
+    } else {
+      store.dispatch({
+        type: 'PLAY_SOUND',
+        sound: 'link',
+      });
+    }
 
-      setConnectFrom(id);
-    },
-  handleResetConnectFrom:
-    ({ setConnectFrom }) =>
-    () =>
-      setConnectFrom(null),
+    setConnectFrom(id);
+  },
+  handleResetConnectFrom: ({ setConnectFrom }) => () => setConnectFrom(null),
 });
 
 const withDropHandlers = withHandlers({
-  accepts:
-    () =>
-    ({ meta }) =>
-      meta.itemType === 'POSITIONED_NODE',
-  onDrop:
-    ({ updateNode, layout, twoMode, width, height, x, y }) =>
-    (item) => {
-      const layoutVariable = twoMode ? layout[item.meta.type] : layout;
-      updateNode(
-        item.meta[entityPrimaryKeyProperty],
-        {},
-        {
-          [layoutVariable]: relativeCoords(
-            {
-              width,
-              height,
-              x,
-              y,
-            },
-            item,
-          ),
-        },
-      );
-    },
+  accepts: () => ({ meta }) => meta.itemType === 'POSITIONED_NODE',
+  onDrop: ({
+    updateNode, layout, twoMode, width, height, x, y,
+  }) => (item) => {
+    const layoutVariable = twoMode ? layout[item.meta.type] : layout;
+    updateNode(
+      item.meta[entityPrimaryKeyProperty],
+      {},
+      {
+        [layoutVariable]: relativeCoords({
+          width, height, x, y,
+        }, item),
+      },
+    );
+  },
 });
 
 const withSelectHandlers = compose(
   withHandlers({
-    connectNode:
-      ({
-        nodes,
-        createEdge,
-        connectFrom,
-        handleConnectFrom,
-        toggleEdge,
-        originRestriction,
-      }) =>
-      (nodeId) => {
-        // If edge creation is disabled, return
-        if (!createEdge) {
-          return;
-        }
+    connectNode: ({
+      nodes,
+      createEdge,
+      connectFrom,
+      handleConnectFrom,
+      toggleEdge,
+      originRestriction,
+    }) => (nodeId) => {
+      // If edge creation is disabled, return
+      if (!createEdge) { return; }
 
-        // If the target and source node are the same, deselect
-        if (connectFrom === nodeId) {
-          handleConnectFrom(null);
-          return;
-        }
-
-        // If there isn't a target node yet, and the type isn't restricted,
-        // set the selected node into the linking state
-        if (!connectFrom) {
-          const nodeType = get(nodes, [nodeId, 'type']);
-
-          // If the node type is restricted, return
-          if (originRestriction && nodeType === originRestriction) {
-            return;
-          }
-
-          handleConnectFrom(nodeId);
-          return;
-        }
-
-        // Either add or remove an edge
-        if (connectFrom !== nodeId) {
-          toggleEdge({
-            from: connectFrom,
-            to: nodeId,
-            type: createEdge,
-          });
-        }
-
-        // Reset the node linking state
+      // If the target and source node are the same, deselect
+      if (connectFrom === nodeId) {
         handleConnectFrom(null);
-      },
-    toggleHighlightAttribute:
-      ({ allowHighlighting, highlightAttribute, toggleHighlight }) =>
-      (node) => {
-        if (!allowHighlighting) {
-          return;
-        }
-        const newVal = !node[entityAttributesProperty][highlightAttribute];
-        toggleHighlight(node[entityPrimaryKeyProperty], {
-          [highlightAttribute]: newVal,
+        return;
+      }
+
+      // If there isn't a target node yet, and the type isn't restricted,
+      // set the selected node into the linking state
+      if (!connectFrom) {
+        const nodeType = get(nodes, [nodeId, 'type']);
+
+        // If the node type is restricted, return
+        if (originRestriction && nodeType === originRestriction) { return; }
+
+        handleConnectFrom(nodeId);
+        return;
+      }
+
+      // Either add or remove an edge
+      if (connectFrom !== nodeId) {
+        toggleEdge({
+          from: connectFrom,
+          to: nodeId,
+          type: createEdge,
         });
-      },
+      }
+
+      // Reset the node linking state
+      handleConnectFrom(null);
+    },
+    toggleHighlightAttribute: ({
+      allowHighlighting, highlightAttribute, toggleHighlight,
+    }) => (node) => {
+      if (!allowHighlighting) { return; }
+      const newVal = !node[entityAttributesProperty][highlightAttribute];
+      toggleHighlight(
+        node[entityPrimaryKeyProperty],
+        { [highlightAttribute]: newVal },
+      );
+    },
   }),
   withHandlers({
-    onSelected:
-      ({ allowHighlighting, connectNode, toggleHighlightAttribute }) =>
-      (node) => {
-        if (!allowHighlighting) {
-          connectNode(node[entityPrimaryKeyProperty]);
-        } else {
-          toggleHighlightAttribute(node);
-        }
-      },
+    onSelected: ({
+      allowHighlighting,
+      connectNode,
+      toggleHighlightAttribute,
+    }) => (node) => {
+      if (!allowHighlighting) {
+        connectNode(node[entityPrimaryKeyProperty]);
+      } else {
+        toggleHighlightAttribute(node);
+      }
+    },
   }),
 );
 
@@ -153,8 +131,7 @@ export default compose(
   withConnectFrom,
   withConnectFromHandler,
   connect(null, mapDispatchToProps),
-  withBounds,
   withDropHandlers,
   withSelectHandlers,
   DropTarget,
-)(NodeLayout);
+)(withBounds(NodeLayout));

--- a/lib/interviewer/containers/Canvas/NodeLayout.js
+++ b/lib/interviewer/containers/Canvas/NodeLayout.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompose';
-import { entityAttributesProperty, entityPrimaryKeyProperty } from '@codaco/shared-consts';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+} from '@codaco/shared-consts';
 import { actionCreators as sessionsActions } from '../../ducks/modules/session';
 import withBounds from '../../behaviours/withBounds';
 import { store } from '../../store';
@@ -16,108 +19,127 @@ const relativeCoords = (container, node) => ({
 const withConnectFrom = withState('connectFrom', 'setConnectFrom', null);
 
 const withConnectFromHandler = withHandlers({
-  handleConnectFrom: ({ setConnectFrom }) => (id) => {
-    if (id === null) {
-      store.dispatch({
-        type: 'STOP_SOUND',
-        sound: 'link',
-      });
-    } else {
-      store.dispatch({
-        type: 'PLAY_SOUND',
-        sound: 'link',
-      });
-    }
+  handleConnectFrom:
+    ({ setConnectFrom }) =>
+    (id) => {
+      if (id === null) {
+        store.dispatch({
+          type: 'STOP_SOUND',
+          sound: 'link',
+        });
+      } else {
+        store.dispatch({
+          type: 'PLAY_SOUND',
+          sound: 'link',
+        });
+      }
 
-    setConnectFrom(id);
-  },
-  handleResetConnectFrom: ({ setConnectFrom }) => () => setConnectFrom(null),
+      setConnectFrom(id);
+    },
+  handleResetConnectFrom:
+    ({ setConnectFrom }) =>
+    () =>
+      setConnectFrom(null),
 });
 
 const withDropHandlers = withHandlers({
-  accepts: () => ({ meta }) => meta.itemType === 'POSITIONED_NODE',
-  onDrop: ({
-    updateNode, layout, twoMode, width, height, x, y,
-  }) => (item) => {
-    const layoutVariable = twoMode ? layout[item.meta.type] : layout;
-    updateNode(
-      item.meta[entityPrimaryKeyProperty],
-      {},
-      {
-        [layoutVariable]: relativeCoords({
-          width, height, x, y,
-        }, item),
-      },
-    );
-  },
+  accepts:
+    () =>
+    ({ meta }) =>
+      meta.itemType === 'POSITIONED_NODE',
+  onDrop:
+    ({ updateNode, layout, twoMode, width, height, x, y }) =>
+    (item) => {
+      const layoutVariable = twoMode ? layout[item.meta.type] : layout;
+      updateNode(
+        item.meta[entityPrimaryKeyProperty],
+        {},
+        {
+          [layoutVariable]: relativeCoords(
+            {
+              width,
+              height,
+              x,
+              y,
+            },
+            item,
+          ),
+        },
+      );
+    },
 });
 
 const withSelectHandlers = compose(
   withHandlers({
-    connectNode: ({
-      nodes,
-      createEdge,
-      connectFrom,
-      handleConnectFrom,
-      toggleEdge,
-      originRestriction,
-    }) => (nodeId) => {
-      // If edge creation is disabled, return
-      if (!createEdge) { return; }
+    connectNode:
+      ({
+        nodes,
+        createEdge,
+        connectFrom,
+        handleConnectFrom,
+        toggleEdge,
+        originRestriction,
+      }) =>
+      (nodeId) => {
+        // If edge creation is disabled, return
+        if (!createEdge) {
+          return;
+        }
 
-      // If the target and source node are the same, deselect
-      if (connectFrom === nodeId) {
+        // If the target and source node are the same, deselect
+        if (connectFrom === nodeId) {
+          handleConnectFrom(null);
+          return;
+        }
+
+        // If there isn't a target node yet, and the type isn't restricted,
+        // set the selected node into the linking state
+        if (!connectFrom) {
+          const nodeType = get(nodes, [nodeId, 'type']);
+
+          // If the node type is restricted, return
+          if (originRestriction && nodeType === originRestriction) {
+            return;
+          }
+
+          handleConnectFrom(nodeId);
+          return;
+        }
+
+        // Either add or remove an edge
+        if (connectFrom !== nodeId) {
+          toggleEdge({
+            from: connectFrom,
+            to: nodeId,
+            type: createEdge,
+          });
+        }
+
+        // Reset the node linking state
         handleConnectFrom(null);
-        return;
-      }
-
-      // If there isn't a target node yet, and the type isn't restricted,
-      // set the selected node into the linking state
-      if (!connectFrom) {
-        const nodeType = get(nodes, [nodeId, 'type']);
-
-        // If the node type is restricted, return
-        if (originRestriction && nodeType === originRestriction) { return; }
-
-        handleConnectFrom(nodeId);
-        return;
-      }
-
-      // Either add or remove an edge
-      if (connectFrom !== nodeId) {
-        toggleEdge({
-          from: connectFrom,
-          to: nodeId,
-          type: createEdge,
+      },
+    toggleHighlightAttribute:
+      ({ allowHighlighting, highlightAttribute, toggleHighlight }) =>
+      (node) => {
+        if (!allowHighlighting) {
+          return;
+        }
+        const newVal = !node[entityAttributesProperty][highlightAttribute];
+        toggleHighlight(node[entityPrimaryKeyProperty], {
+          [highlightAttribute]: newVal,
         });
-      }
-
-      // Reset the node linking state
-      handleConnectFrom(null);
-    },
-    toggleHighlightAttribute: ({
-      allowHighlighting, highlightAttribute, toggleHighlight,
-    }) => (node) => {
-      if (!allowHighlighting) { return; }
-      const newVal = !node[entityAttributesProperty][highlightAttribute];
-      toggleHighlight(
-        node[entityPrimaryKeyProperty],
-        { [highlightAttribute]: newVal },
-      );
-    },
+      },
   }),
   withHandlers({
-    onSelected: ({
-      allowHighlighting,
-      connectNode,
-      toggleHighlightAttribute,
-    }) => (node) => {
-      if (!allowHighlighting) {
-        connectNode(node[entityPrimaryKeyProperty]);
-      } else {
-        toggleHighlightAttribute(node);
-      }
-    },
+    onSelected:
+      ({ allowHighlighting, connectNode, toggleHighlightAttribute }) =>
+      (node) => {
+        if (!allowHighlighting) {
+          connectNode(node[entityPrimaryKeyProperty]);
+        } else {
+          toggleHighlightAttribute(node);
+        }
+      },
   }),
 );
 
@@ -131,7 +153,8 @@ export default compose(
   withConnectFrom,
   withConnectFromHandler,
   connect(null, mapDispatchToProps),
+  withBounds,
   withDropHandlers,
   withSelectHandlers,
   DropTarget,
-)(withBounds(NodeLayout));
+)(NodeLayout);

--- a/lib/interviewer/containers/Canvas/NodeLayout.js
+++ b/lib/interviewer/containers/Canvas/NodeLayout.js
@@ -131,7 +131,8 @@ export default compose(
   withConnectFrom,
   withConnectFromHandler,
   connect(null, mapDispatchToProps),
+  withBounds,
   withDropHandlers,
   withSelectHandlers,
   DropTarget,
-)(withBounds(NodeLayout));
+)(NodeLayout);


### PR DESCRIPTION
[Removing findDOMNode ](https://github.com/complexdatacollective/Fresco/commit/3e753f4d6e04496074630edcfd6535c4a6e5bba5) introduced a bug where dropped nodes were always placed in the top left corner due to width, height, x, y always being undefined. 