### PR TITLE
Feat: Replace planetscale with vercel postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,15 @@
 # When adding additional environment variables, the schema in "/src/env.mjs"
 # should be updated accordingly.
 
-# Prisma
-# https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL=""
+# Vercel Postgres
+POSTGRES_URL="************"
+POSTGRES_PRISMA_URL="************"
+POSTGRES_URL_NO_SSL="************"
+POSTGRES_URL_NON_POOLING="************"
+POSTGRES_USER="************"
+POSTGRES_HOST="************"
+POSTGRES_PASSWORD="************"
+POSTGRES_DATABASE="************"
 
 NEXT_PUBLIC_URL="http://localhost:3000"
 

--- a/env.mjs
+++ b/env.mjs
@@ -8,7 +8,15 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    DATABASE_URL: z.string().url(),
+    // Vercel Postgres env vars
+    POSTGRES_URL: z.string().url().optional(),
+    POSTGRES_PRISMA_URL: z.string().url().optional(),
+    POSTGRES_URL_NO_SSL: z.string().url().optional(),
+    POSTGRES_URL_NON_POOLING: z.string().url().optional(),
+    POSTGRES_USER: z.string().optional(),
+    POSTGRES_HOST: z.string().optional(),
+    POSTGRES_PASSWORD: z.string().optional(),
+    POSTGRES_DATABASE: z.string().optional(),
 
     INSTALLATION_ID: z.string().optional(),
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
-  url          = env("DATABASE_URL")
-  relationMode = "prisma" // Planetscale doesn't support foreign keys yet, so we need to use this
+  provider = "postgresql"
+  url = env("POSTGRES_PRISMA_URL") // uses connection pooling
+  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
 }
 
 model Protocol {


### PR DESCRIPTION
PlanetScale is removing its free tier https://planetscale.com/blog/planetscale-forever. 

This PR implements changes needed to replace planetscale with a Vercel postgres database.

To do:

- [ ] document new process for setting up vercel postgres 