### PR TITLE
fix: assetId not unique

### DIFF
--- a/utils/protocolImport.tsx
+++ b/utils/protocolImport.tsx
@@ -1,5 +1,6 @@
 import type { Protocol } from '@codaco/shared-consts';
 import type Zip from 'jszip';
+import { createId } from '@paralleldrive/cuid2';
 
 // Fetch protocol.json as a parsed object from the protocol zip.
 export const getProtocolJson = async (protocolZip: Zip) => {
@@ -63,7 +64,7 @@ export const getProtocolAssets = async (
       }
 
       files.push({
-        assetId: key,
+        assetId: `${key}_${createId()}`, // We cannot assume key is unique across protocols. Add a unique suffix.
         name: asset.source,
         type: asset.type,
         file: new File([file], asset.source), // Convert Blob to File with filename


### PR DESCRIPTION
Some protocols were failing to import because of a duplicate protocol issue. This was due to the way we use the assetManifest key as the assetId. We cannot actually assume that the assetManifest key is unique given that we allow protocols that are copies of one another if they have made changes.

This PR makes the assetId truly unique by appending a cuid to the key.