### PR TITLE
fix: video loading state not setting to false

### DIFF
--- a/lib/interviewer/components/Video.js
+++ b/lib/interviewer/components/Video.js
@@ -1,9 +1,13 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Loader2 } from 'lucide-react';
 
 const Video = (props) => {
-  const { url, description = 'A video that explains the task.', ...rest } = props;
+  const {
+    url,
+    description = 'A video that explains the task.',
+    ...rest
+  } = props;
   const [loading, setLoading] = useState(true);
 
   const video = useRef();
@@ -22,11 +26,27 @@ const Video = (props) => {
 
   const handleVideoLoaded = () => {
     setLoading(false);
-  }
+  };
+
+  useEffect(() => {
+    if (!video.current) {
+      return;
+    }
+
+    if (video.current.readyState >= 2) {
+      setLoading(false);
+      void video.current.play();
+    }
+  }, [video]);
 
   return (
     <>
-      {loading && <div className='h-full w-full flex items-center justify-center'><Loader2 className='animate-spin mr-4' /><span>Loading video...</span></div>}
+      {loading && (
+        <div className="flex h-full w-full items-center justify-center">
+          <Loader2 className="mr-4 animate-spin" />
+          <span>Loading video...</span>
+        </div>
+      )}
       <video
         {...rest}
         ref={video}
@@ -39,7 +59,7 @@ const Video = (props) => {
       </video>
     </>
   );
-}
+};
 
 Video.propTypes = {
   description: PropTypes.string,


### PR DESCRIPTION
**Bug description:**  Videos were showing a loading spinner endlessly if they had already been accessed in the interview. This was caused by the use of `onCanPlay` to `setLoading(false)`. When the video was retrieved from cache, `onCanPlay` is never fired. 

This fix checks the ready state of the media element in a `useEffect` and calls `setLoading(false)` if the video is ready. This allows for still using cache to improve performance, but having a different way to `setLoading(false)` when the video is retrieved from cache. 