### PR TITLE
Fix/input area text alignment

### DIFF
--- a/lib/ui/styles/components/form/_fields.scss
+++ b/lib/ui/styles/components/form/_fields.scss
@@ -57,7 +57,7 @@ $global-input-border-space: 0.25rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-content: flex-start;
+  align-content: center;
   justify-items: center;
 
   &__inline {

--- a/lib/ui/styles/components/form/_fields.scss
+++ b/lib/ui/styles/components/form/_fields.scss
@@ -57,7 +57,7 @@ $global-input-border-space: 0.25rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-content: center;
+  align-content: flex-start;
   justify-items: center;
 
   &__inline {

--- a/lib/ui/styles/components/form/fields/_text.scss
+++ b/lib/ui/styles/components/form/fields/_text.scss
@@ -75,12 +75,13 @@ $module-name: form-field-text;
   }
 
   &--area {
-    display: block;
+    display: flex;
     width: 100%;
     min-height: 14rem;
     padding-top: 2rem;
     padding-bottom: 2rem;
     resize: vertical;
+    align-content: flex-start;
   }
 
   &--has-right-adornment {

--- a/lib/ui/styles/components/form/fields/_text.scss
+++ b/lib/ui/styles/components/form/fields/_text.scss
@@ -75,7 +75,7 @@ $module-name: form-field-text;
   }
 
   &--area {
-    display: flex;
+    display: block;
     width: 100%;
     min-height: 14rem;
     padding-top: 2rem;


### PR DESCRIPTION
### Bug: 
input area text aligned in center of input
![image](https://github.com/complexdatacollective/Fresco/assets/75645391/a97fe10c-a0f2-44e0-bb9f-eefa8b8e299f)

### Fix: 
Align text at top of input
<img width="1004" alt="Screenshot 2024-04-30 at 2 11 14 PM" src="https://github.com/complexdatacollective/Fresco/assets/75645391/bbc99a26-8b97-4658-8975-d33bb086e6cf">

