### PR TITLE
potential workaround for uploadthing file deletion crashing

### DIFF
--- a/app/(dashboard)/dashboard/interviews/_actions/deleteZipFromUploadThing.ts
+++ b/app/(dashboard)/dashboard/interviews/_actions/deleteZipFromUploadThing.ts
@@ -11,13 +11,9 @@ export const deleteZipFromUploadThing = async (key: string) => {
 
   if (!session) {
     throw new Error(
-      'You must be logged in to delete interview data from UploadThing!.',
+      'You must be logged in to delete interview data from UploadThing!',
     );
   }
 
-  const deleteResponse = await utapi.deleteFiles(key);
-
-  if (!deleteResponse.success) {
-    throw new Error('Failed to delete the zip file from UploadThing');
-  }
+  await utapi.deleteFiles(key);
 };

--- a/app/(dashboard)/dashboard/interviews/_components/ExportInterviewsDialog.tsx
+++ b/app/(dashboard)/dashboard/interviews/_components/ExportInterviewsDialog.tsx
@@ -135,7 +135,7 @@ export const ExportInterviewsDialog = ({
             variant: 'default',
             title: 'Could not delete temp file',
             description:
-              'We were unable to delete the temporary file stored on your UploadThing account. Although extremely unlikely, it is possible that this file could be accessed by someone else. You can delete the file manually by visiting uploadthing.com and logging in with your GitHub account. If you have any concerns, please contact info@networkcanvas.com.',
+              'We were unable to delete the temporary file stored on your UploadThing account. Although extremely unlikely, it is possible that this file could be accessed by someone else. You can delete the file manually by visiting uploadthing.com and logging in with your GitHub account. Please use the feedback button to report this issue.',
           });
         });
       }


### PR DESCRIPTION
This PR changes the way temp file deletion works during the export process.

- It calls the deleteZipFromUploadThing method in the `finally` block, which both prevents deletion from cancelling the export, and allows us to potentially clean up even if the export fails.
- It adds a user toast with messaging in the scenario that the deletion files, so that the user can manually delete any sensitive data.