### PR TITLE
Fix/tie strength edges

### DIFF
--- a/lib/interviewer/containers/Interfaces/TieStrengthCensus/Pair.js
+++ b/lib/interviewer/containers/Interfaces/TieStrengthCensus/Pair.js
@@ -46,8 +46,8 @@ const Pair = ({
   const pairVariants = getPairVariants();
 
   const edgeVariants = {
-    hideEdge: { backgroundPosition: 'right bottom' },
-    showEdge: { backgroundPosition: 'left bottom' },
+    hideEdge: { scaleX: 0, transformOrigin: 'left bottom' },
+    showEdge: { scaleX: 1, transformOrigin: 'left bottom' },
   };
 
   return (

--- a/lib/interviewer/containers/Interfaces/TieStrengthCensus/Pair.js
+++ b/lib/interviewer/containers/Interfaces/TieStrengthCensus/Pair.js
@@ -46,8 +46,8 @@ const Pair = ({
   const pairVariants = getPairVariants();
 
   const edgeVariants = {
-    hideEdge: { scaleX: 0, transformOrigin: 'left bottom' },
-    showEdge: { scaleX: 1, transformOrigin: 'left bottom' },
+    hideEdge: { backgroundPosition: 'right bottom' },
+    showEdge: { backgroundPosition: 'left bottom' },
   };
 
   return (
@@ -59,12 +59,14 @@ const Pair = ({
       initial="initial"
       animate="show"
       exit="hide"
+      style={{
+        '--edge-color': `var(--nc-${edgeColor})`,
+      }}
     >
       <div className="dyad-census__nodes">
         <Node {...fromNode} />
         <motion.div
           className="dyad-census__edge"
-          style={{ backgroundColor: `var(--nc-${edgeColor})` }}
           variants={edgeVariants}
           initial="hideEdge"
           animate={!hasEdge ? 'hideEdge' : 'showEdge'}


### PR DESCRIPTION
### Bug: 
Edges between nodes on tie strength census are visible regardless of `hasEdge` prop.

![image](https://github.com/complexdatacollective/Fresco/assets/75645391/1b9853be-5a3d-42d3-895c-453b00d4ddfc)


### Expected behavior:
Initially, no edge should be shown.
If an option is selected, an edge should animate in from the left
If an edge is removed, edge should animate out from the right

### Fix:
Moving style to the parent `dyad-census__pair` div as in ebef478 fixes the issue.