### PR TITLE
Fix: empty export files

### DIFF
--- a/lib/network-exporters/formatters/formatExportableSessions.ts
+++ b/lib/network-exporters/formatters/formatExportableSessions.ts
@@ -63,8 +63,8 @@ export const formatExportableSessions = (
     const sessionNetwork = session.network as unknown as NcNetwork;
 
     return {
-      sessionNetwork,
+      ...sessionNetwork,
       sessionVariables,
-    } as FormattedSession;
+    };
   });
 };

--- a/lib/network-exporters/formatters/formatExportableSessions.ts
+++ b/lib/network-exporters/formatters/formatExportableSessions.ts
@@ -8,13 +8,18 @@ import {
   sessionFinishTimeProperty,
   sessionProperty,
   sessionStartTimeProperty,
+  type NcNode,
+  type NcEntity,
+  type NcEdge,
 } from '@codaco/shared-consts';
 import { hash } from 'ohash';
 import { env } from '~/env.mjs';
 import type { RouterOutputs } from '~/trpc/shared';
 
 type FormattedSession = {
-  sessionNetwork: NcNetwork;
+  ego: NcEntity | undefined;
+  nodes: NcNode[];
+  edges: NcEdge[];
   sessionVariables: {
     [caseProperty]: string;
     [sessionProperty]: string;
@@ -65,6 +70,6 @@ export const formatExportableSessions = (
     return {
       ...sessionNetwork,
       sessionVariables,
-    };
+    } as FormattedSession;
   });
 };


### PR DESCRIPTION
Fixes bug where exported files did not have ego, alter, or edge data (only session data).