### PR TITLE
Fix activity feed

### DIFF
--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -15,5 +15,5 @@ export async function GET(request: NextRequest) {
 
   const activities = await getActivities(params);
 
-  return NextResponse.json({ data: activities });
+  return NextResponse.json(activities);
 }

--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -1,19 +1,16 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { type SearchParams } from 'nuqs/server';
+import { searchParamsCache } from '~/app/dashboard/_components/ActivityFeed/searchParamsCache';
 import { getActivities } from '~/queries/activityFeed';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
 
-  // Parse the search parameters back to their original form
-  const params = {
-    page: Number(searchParams.get('page')),
-    perPage: Number(searchParams.get('perPage')),
-    sort: searchParams.get('sort'),
-    sortField: searchParams.get('sortField'),
-    filterParams: JSON.parse(searchParams.get('filterParams') ?? 'null'),
-  };
+  const parsedParams = searchParamsCache.parse(
+    searchParams as unknown as SearchParams,
+  );
 
-  const activities = await getActivities(params);
+  const activities = await getActivities(parsedParams);
 
   return NextResponse.json(activities);
 }

--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getActivities } from '~/queries/activityFeed';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+
+  // Parse the search parameters back to their original form
+  const params = {
+    page: Number(searchParams.get('page')),
+    perPage: Number(searchParams.get('perPage')),
+    sort: searchParams.get('sort'),
+    sortField: searchParams.get('sortField'),
+    filterParams: JSON.parse(searchParams.get('filterParams') ?? 'null'),
+  };
+
+  const activities = await getActivities(params);
+
+  return NextResponse.json({ data: activities });
+}

--- a/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { hash } from 'ohash';
 import { DataTableSkeleton } from '~/components/data-table/data-table-skeleton';
 import ActivityFeedTable from './ActivityFeedTable';
 import { useTableStateFromSearchParams } from './useTableStateFromSearchParams';
@@ -21,7 +22,7 @@ const ActivityFeed = () => {
   };
 
   const { isLoading, data } = useQuery({
-    queryKey: ['activities'],
+    queryKey: ['activities', hash(params)],
     queryFn: () =>
       fetch('/api/activities?' + new URLSearchParams(params).toString()).then(
         (res) => res.json(),

--- a/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
@@ -9,17 +9,19 @@ import { useTableStateFromSearchParams } from './useTableStateFromSearchParams';
 const ActivityFeed = () => {
   const { searchParams } = useTableStateFromSearchParams();
 
-  // Stringify filterParams
-  const filterParams = JSON.stringify(searchParams.filterParams);
+  function convertObjectToStringRecord(
+    obj: Record<string, unknown>,
+  ): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        result[key] = String(obj[key]);
+      }
+    }
+    return result;
+  }
 
-  // Convert all values to strings
-  const params = {
-    page: String(searchParams.page),
-    perPage: String(searchParams.perPage),
-    sort: searchParams.sort,
-    sortField: searchParams.sortField,
-    filterParams,
-  };
+  const params = convertObjectToStringRecord(searchParams);
 
   const { isLoading, data } = useQuery({
     queryKey: ['activities', hash(params)],

--- a/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
@@ -1,8 +1,8 @@
-import { DataTableSkeleton } from '~/components/data-table/data-table-skeleton';
-import ActivityFeedTable from './ActivityFeedTable';
 import { Suspense } from 'react';
-import { searchParamsCache } from './searchParamsCache';
+import { DataTableSkeleton } from '~/components/data-table/data-table-skeleton';
 import { getActivities } from '~/queries/activityFeed';
+import ActivityFeedTable from './ActivityFeedTable';
+import { searchParamsCache } from './searchParamsCache';
 
 export default function ActivityFeed() {
   const searchParams = searchParamsCache.all();

--- a/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
@@ -23,7 +23,7 @@ export default function ActivityFeedTable({
     [],
   );
 
-  const data = tableData.data as ActivitiesFeed;
+  const data = tableData as ActivitiesFeed;
 
   const { dataTable } = useDataTable({
     data: data.events,

--- a/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
@@ -2,10 +2,10 @@
 
 import type { Events } from '@prisma/client';
 import type { ColumnDef } from '@tanstack/react-table';
-import { use, useMemo } from 'react';
+import { useMemo } from 'react';
 import { DataTable } from '~/components/data-table/data-table';
 import { useDataTable } from '~/hooks/use-data-table';
-import type { ActivitiesFeed } from '~/queries/activityFeed';
+import { type ActivitiesFeed } from '~/queries/activityFeed';
 import {
   fetchActivityFeedTableColumnDefs,
   filterableColumns,
@@ -13,22 +13,22 @@ import {
 } from './ColumnDefinition';
 
 export default function ActivityFeedTable({
-  activitiesPromise,
+  tableData,
 }: {
-  activitiesPromise: ActivitiesFeed;
+  tableData: unknown;
 }) {
-  const tableData = use(activitiesPromise);
-
   // Memoize the columns so they don't re-render on every render
   const columns = useMemo<ColumnDef<Events, unknown>[]>(
     () => fetchActivityFeedTableColumnDefs(),
     [],
   );
 
+  const data = tableData as ActivitiesFeed;
+
   const { dataTable } = useDataTable({
-    data: tableData.events,
+    data: data.events,
     columns,
-    pageCount: tableData.pageCount,
+    pageCount: data.pageCount,
     searchableColumns,
     filterableColumns,
   });

--- a/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
@@ -23,7 +23,7 @@ export default function ActivityFeedTable({
     [],
   );
 
-  const data = tableData as ActivitiesFeed;
+  const data = tableData.data as ActivitiesFeed;
 
   const { dataTable } = useDataTable({
     data: data.events,

--- a/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { use, useMemo } from 'react';
+import type { Events } from '@prisma/client';
 import type { ColumnDef } from '@tanstack/react-table';
-import { useDataTable } from '~/hooks/use-data-table';
+import { use, useMemo } from 'react';
 import { DataTable } from '~/components/data-table/data-table';
+import { useDataTable } from '~/hooks/use-data-table';
+import type { ActivitiesFeed } from '~/queries/activityFeed';
 import {
   fetchActivityFeedTableColumnDefs,
-  searchableColumns,
   filterableColumns,
+  searchableColumns,
 } from './ColumnDefinition';
-import type { Events } from '@prisma/client';
-import type { ActivitiesFeed } from '~/queries/activityFeed';
 
 export default function ActivityFeedTable({
   activitiesPromise,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,15 +1,15 @@
-import ResponsiveContainer from '~/components/ResponsiveContainer';
-import Heading from '~/components/ui/typography/Heading';
-import Section from '~/components/layout/Section';
-import PageHeader from '~/components/ui/typography/PageHeader';
-import ActivityFeed from './_components/ActivityFeed/ActivityFeed';
-import Paragraph from '~/components/ui/typography/Paragraph';
-import SummaryStatistics from './_components/SummaryStatistics/SummaryStatistics';
-import AnonymousRecruitmentWarning from './protocols/_components/AnonymousRecruitmentWarning';
 import { Suspense } from 'react';
-import { searchParamsCache } from './_components/ActivityFeed/searchParamsCache';
+import ResponsiveContainer from '~/components/ResponsiveContainer';
+import Section from '~/components/layout/Section';
+import Heading from '~/components/ui/typography/Heading';
+import PageHeader from '~/components/ui/typography/PageHeader';
+import Paragraph from '~/components/ui/typography/Paragraph';
 import { requireAppNotExpired } from '~/queries/appSettings';
 import { requirePageAuth } from '~/utils/auth';
+import ActivityFeed from './_components/ActivityFeed/ActivityFeed';
+import { searchParamsCache } from './_components/ActivityFeed/searchParamsCache';
+import SummaryStatistics from './_components/SummaryStatistics/SummaryStatistics';
+import AnonymousRecruitmentWarning from './protocols/_components/AnonymousRecruitmentWarning';
 
 export default async function Home({
   searchParams,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Section from '~/components/layout/Section';
 import Heading from '~/components/ui/typography/Heading';
 import PageHeader from '~/components/ui/typography/PageHeader';
 import Paragraph from '~/components/ui/typography/Paragraph';
+import ReactQueryProvider from '~/lib/query-provider';
 import { requireAppNotExpired } from '~/queries/appSettings';
 import { requirePageAuth } from '~/utils/auth';
 import ActivityFeed from './_components/ActivityFeed/ActivityFeed';
@@ -42,7 +43,9 @@ export default async function Home({
       </ResponsiveContainer>
       <ResponsiveContainer maxWidth="6xl">
         <Section>
-          <ActivityFeed />
+          <ReactQueryProvider>
+            <ActivityFeed />
+          </ReactQueryProvider>
         </Section>
       </ResponsiveContainer>
     </>

--- a/components/data-table/data-table-toolbar.tsx
+++ b/components/data-table/data-table-toolbar.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import * as React from 'react';
-import Link from 'next/link';
 import type { Table } from '@tanstack/react-table';
+import { PlusCircle, Trash, X } from 'lucide-react';
+import Link from 'next/link';
+import * as React from 'react';
+import { type UrlObject } from 'url';
+import { DataTableFacetedFilter } from '~/components/data-table/data-table-faceted-filter';
 import { Button, buttonVariants } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
-import { DataTableFacetedFilter } from '~/components/data-table/data-table-faceted-filter';
 import {
   type DataTableFilterableColumn,
   type DataTableSearchableColumn,
 } from '~/lib/data-table/types';
-import { PlusCircle, Trash, X } from 'lucide-react';
 import { cn } from '~/utils/shadcn';
-import { type UrlObject } from 'url';
 
 type DataTableToolbarProps<TData> = {
   table: Table<TData>;

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import {
   flexRender,
   type ColumnDef,
   type Table as TanstackTable,
 } from '@tanstack/react-table';
+import * as React from 'react';
 
 import {
   Table,
@@ -14,14 +14,14 @@ import {
   TableRow,
 } from '~/components/ui/table';
 
-import { DataTableAdvancedToolbar } from './advanced/data-table-advanced-toolbar';
-import { DataTableFloatingBar } from './data-table-floating-bar';
-import { DataTablePagination } from './data-table-pagination';
-import { DataTableToolbar } from './data-table-toolbar';
 import type {
   DataTableFilterableColumn,
   DataTableSearchableColumn,
 } from '~/lib/data-table/types';
+import { DataTableAdvancedToolbar } from './advanced/data-table-advanced-toolbar';
+import { DataTableFloatingBar } from './data-table-floating-bar';
+import { DataTablePagination } from './data-table-pagination';
+import { DataTableToolbar } from './data-table-toolbar';
 
 type DataTableProps<TData, TValue> = {
   /**

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -23,7 +23,7 @@ import type {
   SortableField,
 } from '~/lib/data-table/types';
 
-import { debounce, isEqual } from 'lodash';
+import { debounce } from 'lodash';
 import { useRouter } from 'next/navigation';
 import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
 
@@ -121,10 +121,6 @@ export function useDataTable<TData, TValue>({
 
   // Sync any changes to columnFilters back to searchParams
   React.useEffect(() => {
-    // Deep compare the columnFilters and searchParams.filterParams
-    if (isEqual(columnFilters, searchParams.filterParams)) {
-      return;
-    }
     // If we are resetting, skip the debounce
     if (!columnFilters || columnFilters.length === 0) {
       void setSearchParams.setFilterParams(null).then(() => {

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import {
   getCoreRowModel,
   getFacetedRowModel,
@@ -15,6 +14,7 @@ import {
   type SortingState,
   type VisibilityState,
 } from '@tanstack/react-table';
+import * as React from 'react';
 import type {
   DataTableFilterableColumn,
   DataTableSearchableColumn,

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -24,9 +24,8 @@ import type {
 } from '~/lib/data-table/types';
 
 import { debounce } from 'lodash';
-import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
-
 import { useRouter } from 'next/navigation';
+import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
 
 type UseDataTableProps<TData, TValue> = {
   /**
@@ -101,13 +100,15 @@ export function useDataTable<TData, TValue>({
   const debouncedUpdateFilterParams = debounce(
     (columnFilters: FilterParam[]) => {
       if (!columnFilters || columnFilters.length === 0) {
-        void setSearchParams.setFilterParams(null);
-        router.refresh();
+        void setSearchParams.setFilterParams(null).then(() => {
+          router.refresh();
+        });
         return;
       }
 
-      void setSearchParams.setFilterParams(columnFilters);
-      router.refresh();
+      void setSearchParams.setFilterParams(columnFilters).then(() => {
+        router.refresh();
+      });
       // Changing the filter params should reset the page to 1
       // void setSearchParams.setPage(1);
     },
@@ -122,16 +123,18 @@ export function useDataTable<TData, TValue>({
   React.useEffect(() => {
     // If we are resetting, skip the debounce
     if (!columnFilters || columnFilters.length === 0) {
-      void setSearchParams.setFilterParams(null);
-      router.refresh();
+      void setSearchParams.setFilterParams(null).then(() => {
+        router.refresh();
+      });
       return;
     }
 
     debouncedUpdateFilterParams(columnFilters as FilterParam[]);
 
     // Changing the filter params should reset the page to 1
-    void setSearchParams.setPage(1);
-    router.refresh();
+    void setSearchParams.setPage(1).then(() => {
+      router.refresh();
+    });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnFilters]);
@@ -144,9 +147,13 @@ export function useDataTable<TData, TValue>({
   }, [searchParams.page, searchParams.perPage]);
 
   React.useEffect(() => {
-    void setSearchParams.setPage(pageIndex + 1);
-    void setSearchParams.setPerPage(pageSize as PageSize);
-    router.refresh();
+    void setSearchParams.setPage(pageIndex + 1).then(() => {
+      router.refresh();
+    });
+    void setSearchParams.setPerPage(pageSize as PageSize).then(() => {
+      router.refresh();
+    });
+    //router.refresh();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageIndex, pageSize]);
@@ -160,8 +167,11 @@ export function useDataTable<TData, TValue>({
 
   React.useEffect(() => {
     void setSearchParams.setSort(sorting[0]?.desc ? 'desc' : 'asc');
-    void setSearchParams.setSortField(sorting[0]?.id as SortableField);
-    router.refresh();
+    void setSearchParams
+      .setSortField(sorting[0]?.id as SortableField)
+      .then(() => {
+        router.refresh();
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting]);
 

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -23,7 +23,7 @@ import type {
   SortableField,
 } from '~/lib/data-table/types';
 
-import { debounce } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 import { useRouter } from 'next/navigation';
 import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
 
@@ -121,6 +121,10 @@ export function useDataTable<TData, TValue>({
 
   // Sync any changes to columnFilters back to searchParams
   React.useEffect(() => {
+    // Deep compare the columnFilters and searchParams.filterParams
+    if (isEqual(columnFilters, searchParams.filterParams)) {
+      return;
+    }
     // If we are resetting, skip the debounce
     if (!columnFilters || columnFilters.length === 0) {
       void setSearchParams.setFilterParams(null).then(() => {

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -23,8 +23,10 @@ import type {
   SortableField,
 } from '~/lib/data-table/types';
 
-import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
 import { debounce } from 'lodash';
+import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
+
+import { useRouter } from 'next/navigation';
 
 type UseDataTableProps<TData, TValue> = {
   /**
@@ -68,10 +70,11 @@ export function useDataTable<TData, TValue>({
   data,
   columns,
   pageCount, // Todo: the below should be used to filter filter/search terms before setting search params
-} // searchableColumns = [],
-// filterableColumns = [],
-: UseDataTableProps<TData, TValue>) {
+  // searchableColumns = [],
+  // filterableColumns = [],
+}: UseDataTableProps<TData, TValue>) {
   const { searchParams, setSearchParams } = useTableStateFromSearchParams();
+  const router = useRouter();
 
   // Table states
   const [rowSelection, setRowSelection] = React.useState({});
@@ -99,10 +102,12 @@ export function useDataTable<TData, TValue>({
     (columnFilters: FilterParam[]) => {
       if (!columnFilters || columnFilters.length === 0) {
         void setSearchParams.setFilterParams(null);
+        router.refresh();
         return;
       }
 
       void setSearchParams.setFilterParams(columnFilters);
+      router.refresh();
       // Changing the filter params should reset the page to 1
       // void setSearchParams.setPage(1);
     },
@@ -118,6 +123,7 @@ export function useDataTable<TData, TValue>({
     // If we are resetting, skip the debounce
     if (!columnFilters || columnFilters.length === 0) {
       void setSearchParams.setFilterParams(null);
+      router.refresh();
       return;
     }
 
@@ -125,6 +131,7 @@ export function useDataTable<TData, TValue>({
 
     // Changing the filter params should reset the page to 1
     void setSearchParams.setPage(1);
+    router.refresh();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnFilters]);
@@ -139,6 +146,7 @@ export function useDataTable<TData, TValue>({
   React.useEffect(() => {
     void setSearchParams.setPage(pageIndex + 1);
     void setSearchParams.setPerPage(pageSize as PageSize);
+    router.refresh();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageIndex, pageSize]);
@@ -153,6 +161,7 @@ export function useDataTable<TData, TValue>({
   React.useEffect(() => {
     void setSearchParams.setSort(sorting[0]?.desc ? 'desc' : 'asc');
     void setSearchParams.setSortField(sorting[0]?.id as SortableField);
+    router.refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting]);
 

--- a/lib/query-provider.tsx
+++ b/lib/query-provider.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function ReactQueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.7",
+    "@tanstack/react-query": "^5.37.1",
     "@tanstack/react-table": "^8.16.0",
     "@types/async": "^3.2.24",
     "@uploadthing/react": "^6.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@tailwindcss/forms':
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.4.5)))
+      '@tanstack/react-query':
+        specifier: ^5.37.1
+        version: 5.37.1(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.16.0
         version: 8.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1682,6 +1685,14 @@ packages:
     resolution: {integrity: sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
+
+  '@tanstack/query-core@5.36.1':
+    resolution: {integrity: sha512-BteWYEPUcucEu3NBcDAgKuI4U25R9aPrHSP6YSf2NvaD2pSlIQTdqOfLRsxH9WdRYg7k0Uom35Uacb6nvbIMJg==}
+
+  '@tanstack/react-query@5.37.1':
+    resolution: {integrity: sha512-EhtBNA8GL3XFeSx6VYUjXQ96n44xe3JGKZCzBINrCYlxbZP6UwBafv7ti4eSRWc2Fy+fybQre0w17gR6lMzULA==}
+    peerDependencies:
+      react: ^18.0.0
 
   '@tanstack/react-table@8.16.0':
     resolution: {integrity: sha512-rKRjnt8ostqN2fercRVOIH/dq7MAmOENCMvVlKx6P9Iokhh6woBGnIZEkqsY/vEJf1jN3TqLOb34xQGLVRuhAg==}
@@ -6770,6 +6781,13 @@ snapshots:
     dependencies:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.12.8)(typescript@5.4.5))
+
+  '@tanstack/query-core@5.36.1': {}
+
+  '@tanstack/react-query@5.37.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.36.1
+      react: 18.3.1
 
   '@tanstack/react-table@8.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/queries/activityFeed.ts
+++ b/queries/activityFeed.ts
@@ -9,13 +9,13 @@ export const getActivities = (searchParams: unknown) =>
       // Convert searchParams to the expected type
       const searchParams = rawSearchParams as SearchParams;
 
-      // Destructure searchParams object
       const { page, perPage, sort, sortField, filterParams } = searchParams;
 
-      // Calculate offset for pagination
+      // Number of items to skip
       const offset = page > 0 ? (page - 1) * perPage : 0;
 
-      // Generate filter parameters for the database query
+      // Generate the dynamic filter parameters for the database call from the
+      // input filter params.
       const queryFilterParams = filterParams
         ? {
             OR: [
@@ -29,7 +29,7 @@ export const getActivities = (searchParams: unknown) =>
           }
         : {};
 
-      // Execute both count and findMany queries in a single transaction
+      // Transaction is used to ensure both queries are executed in a single transaction
       const [count, events] = await prisma.$transaction([
         prisma.events.count({
           where: {
@@ -46,10 +46,8 @@ export const getActivities = (searchParams: unknown) =>
         }),
       ]);
 
-      // Calculate pageCount
       const pageCount = Math.ceil(count / perPage);
 
-      // Return events and pageCount
       return { events, pageCount };
     },
     ['getActivities'],

--- a/queries/activityFeed.ts
+++ b/queries/activityFeed.ts
@@ -57,4 +57,5 @@ export const getActivities = (searchParams: unknown) =>
     },
   )(searchParams);
 
-export type ActivitiesFeed = ReturnType<typeof getActivities>;
+export type ActivitiesFeed =
+  ReturnType<typeof getActivities> extends Promise<infer R> ? R : never;

--- a/queries/activityFeed.ts
+++ b/queries/activityFeed.ts
@@ -1,57 +1,61 @@
 import { unstable_cache } from 'next/cache';
+import 'server-only';
 import { type SearchParams } from '~/lib/data-table/types';
 import { prisma } from '~/utils/db';
-import 'server-only';
 
-export const getActivities = unstable_cache(
-  async (rawSearchParams: unknown) => {
-    // const searchParams = SearchParamsSchema.parse(rawSearchParams);
-    const searchParams = rawSearchParams as SearchParams;
+export const getActivities = (searchParams: unknown) =>
+  unstable_cache(
+    async (rawSearchParams: unknown) => {
+      // Convert searchParams to the expected type
+      const searchParams = rawSearchParams as SearchParams;
 
-    const { page, perPage, sort, sortField, filterParams } = searchParams;
+      // Destructure searchParams object
+      const { page, perPage, sort, sortField, filterParams } = searchParams;
 
-    // Number of items to skip
-    const offset = page > 0 ? (page - 1) * perPage : 0;
+      // Calculate offset for pagination
+      const offset = page > 0 ? (page - 1) * perPage : 0;
 
-    // Generate the dynamic filter parameters for the database call from the
-    // input filter params.
-    const queryFilterParams = filterParams
-      ? {
-          OR: [
-            ...filterParams.map(({ id, value }) => {
-              const operator = Array.isArray(value) ? 'in' : 'contains';
-              return {
-                [id]: { [operator]: value },
-              };
-            }),
-          ],
-        }
-      : {};
+      // Generate filter parameters for the database query
+      const queryFilterParams = filterParams
+        ? {
+            OR: [
+              ...filterParams.map(({ id, value }) => {
+                const operator = Array.isArray(value) ? 'in' : 'contains';
+                return {
+                  [id]: { [operator]: value },
+                };
+              }),
+            ],
+          }
+        : {};
 
-    // Transaction is used to ensure both queries are executed in a single transaction
-    const [count, events] = await prisma.$transaction([
-      prisma.events.count({
-        where: {
-          ...queryFilterParams,
-        },
-      }),
-      prisma.events.findMany({
-        take: perPage,
-        skip: offset,
-        orderBy: { [sortField]: sort },
-        where: {
-          ...queryFilterParams,
-        },
-      }),
-    ]);
+      // Execute both count and findMany queries in a single transaction
+      const [count, events] = await prisma.$transaction([
+        prisma.events.count({
+          where: {
+            ...queryFilterParams,
+          },
+        }),
+        prisma.events.findMany({
+          take: perPage,
+          skip: offset,
+          orderBy: { [sortField]: sort },
+          where: {
+            ...queryFilterParams,
+          },
+        }),
+      ]);
 
-    const pageCount = Math.ceil(count / perPage);
-    return { events, pageCount };
-  },
-  ['activityFeed'],
-  {
-    tags: ['activityFeed'],
-  },
-);
+      // Calculate pageCount
+      const pageCount = Math.ceil(count / perPage);
+
+      // Return events and pageCount
+      return { events, pageCount };
+    },
+    ['getActivities'],
+    {
+      tags: [`getActivities`, `getActivities-${JSON.stringify(searchParams)}`],
+    },
+  )(searchParams);
 
 export type ActivitiesFeed = ReturnType<typeof getActivities>;

--- a/queries/activityFeed.ts
+++ b/queries/activityFeed.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { hash } from 'ohash';
 import 'server-only';
 import { type SearchParams } from '~/lib/data-table/types';
 import { prisma } from '~/utils/db';
@@ -52,7 +53,7 @@ export const getActivities = (searchParams: unknown) =>
     },
     ['getActivities'],
     {
-      tags: [`getActivities`, `getActivities-${JSON.stringify(searchParams)}`],
+      tags: [`getActivities`, `getActivities-${hash(searchParams)}`],
     },
   )(searchParams);
 


### PR DESCRIPTION
Activity feed table was not updating with changes to the search params.

This fixes that issue by calling `router.refresh()` after updating the params and including the hashed params object in the cache key.