### PR TITLE
reimplement activity feed table as client component

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,11 +18,12 @@ const config = {
   parserOptions: {
     project: path.join(__dirname, 'tsconfig.json'),
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', '@tanstack/query',],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/stylistic',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@tanstack/eslint-plugin-query/recommended',
     'next/core-web-vitals',
     'prettier',
   ],

--- a/app/api/activity-feed/route.ts
+++ b/app/api/activity-feed/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { searchParamsCache } from '~/app/dashboard/_components/ActivityFeed/SearchParams';
+import { getActivities } from '~/queries/activityFeed';
+import { requireApiAuth } from '~/utils/auth';
+
+export async function GET(request: NextRequest) {
+  await requireApiAuth();
+
+  const rawParams = request.nextUrl.searchParams.entries();
+  const searchParams = searchParamsCache.parse(Object.fromEntries(rawParams));
+
+  const result = await getActivities(searchParams);
+  return NextResponse.json(result);
+}

--- a/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeed.tsx
@@ -1,18 +1,28 @@
+'use client';
+
+import type { Events } from '@prisma/client';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
 import { DataTableSkeleton } from '~/components/data-table/data-table-skeleton';
 import ActivityFeedTable from './ActivityFeedTable';
-import { Suspense } from 'react';
-import { searchParamsCache } from './searchParamsCache';
-import { getActivities } from '~/queries/activityFeed';
 
-export default function ActivityFeed() {
-  const searchParams = searchParamsCache.all();
-  const activitiesPromise = getActivities(searchParams);
+export const ActivityFeed = () => {
+  const params = useSearchParams();
 
-  return (
-    <Suspense
-      fallback={<DataTableSkeleton columnCount={3} filterableColumnCount={1} />}
-    >
-      <ActivityFeedTable activitiesPromise={activitiesPromise} />
-    </Suspense>
-  );
-}
+  const { isPending, data } = useQuery({
+    queryKey: ['activityFeed', params.toString()],
+    queryFn: async () => {
+      const response = await fetch(`/api/activity-feed?${params.toString()}`);
+      return response.json() as Promise<{
+        events: Events[];
+        pageCount: number;
+      }>;
+    },
+  });
+
+  if (isPending || !data) {
+    return <DataTableSkeleton columnCount={3} filterableColumnCount={1} />;
+  }
+
+  return <ActivityFeedTable tableData={data} />;
+};

--- a/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
+++ b/app/dashboard/_components/ActivityFeed/ActivityFeedTable.tsx
@@ -1,24 +1,21 @@
 'use client';
 
-import { use, useMemo } from 'react';
+import type { Events } from '@prisma/client';
 import type { ColumnDef } from '@tanstack/react-table';
-import { useDataTable } from '~/hooks/use-data-table';
+import { useMemo } from 'react';
 import { DataTable } from '~/components/data-table/data-table';
+import { useDataTable } from '~/hooks/use-data-table';
 import {
   fetchActivityFeedTableColumnDefs,
-  searchableColumns,
   filterableColumns,
+  searchableColumns,
 } from './ColumnDefinition';
-import type { Events } from '@prisma/client';
-import type { ActivitiesFeed } from '~/queries/activityFeed';
 
 export default function ActivityFeedTable({
-  activitiesPromise,
+  tableData,
 }: {
-  activitiesPromise: ActivitiesFeed;
+  tableData: { events: Events[]; pageCount: number };
 }) {
-  const tableData = use(activitiesPromise);
-
   // Memoize the columns so they don't re-render on every render
   const columns = useMemo<ColumnDef<Events, unknown>[]>(
     () => fetchActivityFeedTableColumnDefs(),
@@ -39,6 +36,8 @@ export default function ActivityFeedTable({
       columns={columns}
       searchableColumns={searchableColumns}
       filterableColumns={filterableColumns}
+      // floatingBarContent={TasksTableFloatingBarContent(dataTable)}
+      // deleteRowsAction={(_event) => {}}
     />
   );
 }

--- a/app/dashboard/_components/ActivityFeed/SearchParams.tsx
+++ b/app/dashboard/_components/ActivityFeed/SearchParams.tsx
@@ -1,22 +1,15 @@
 import {
-  FilterParam,
-  pageSizes,
-  sortOrder,
-  sortableFields,
-} from '~/lib/data-table/types';
-
-import {
+  createSearchParamsCache,
   parseAsArrayOf,
   parseAsInteger,
   parseAsJson,
-  parseAsNumberLiteral,
   parseAsStringLiteral,
-} from 'nuqs';
-import { createSearchParamsCache } from 'nuqs/server';
+} from 'nuqs/server';
+import { FilterParam, sortOrder, sortableFields } from '~/lib/data-table/types';
 
-export const parsers = {
+export const searchParamsParsers = {
   page: parseAsInteger.withDefault(1),
-  perPage: parseAsNumberLiteral(pageSizes).withDefault(10),
+  perPage: parseAsInteger.withDefault(10),
   sort: parseAsStringLiteral(sortOrder).withDefault('desc'),
   sortField: parseAsStringLiteral(sortableFields).withDefault('timestamp'),
   filterParams: parseAsArrayOf(
@@ -24,4 +17,4 @@ export const parsers = {
   ),
 };
 
-export const searchParamsCache = createSearchParamsCache(parsers);
+export const searchParamsCache = createSearchParamsCache(searchParamsParsers);

--- a/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams.ts
+++ b/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams.ts
@@ -1,7 +1,6 @@
 'use client';
-
-import { useQueryState } from 'nuqs';
-import { parsers } from './searchParamsCache';
+import { useQueryStates } from 'nuqs';
+import { searchParamsParsers } from './SearchParams';
 
 /**
  * This hook implements the table state items required by the DataTable.
@@ -13,18 +12,8 @@ import { parsers } from './searchParamsCache';
  *
  */
 export const useTableStateFromSearchParams = () => {
-  const [page, setPage] = useQueryState('page', parsers.page);
-  const [perPage, setPerPage] = useQueryState('perPage', parsers.perPage);
-  const [sort, setSort] = useQueryState('sort', parsers.sort);
-  const [sortField, setSortField] = useQueryState(
-    'sortField',
-    parsers.sortField,
-  );
-
-  const [filterParams, setFilterParams] = useQueryState(
-    'filterParams',
-    parsers.filterParams,
-  );
+  const [{ page, perPage, sort, sortField, filterParams }, setSearchParams] =
+    useQueryStates(searchParamsParsers);
 
   return {
     searchParams: {
@@ -34,12 +23,6 @@ export const useTableStateFromSearchParams = () => {
       sortField,
       filterParams,
     },
-    setSearchParams: {
-      setPage,
-      setPerPage,
-      setSort,
-      setSortField,
-      setFilterParams,
-    },
+    setSearchParams,
   };
 };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,20 +6,13 @@ import PageHeader from '~/components/ui/typography/PageHeader';
 import Paragraph from '~/components/ui/typography/Paragraph';
 import { requireAppNotExpired } from '~/queries/appSettings';
 import { requirePageAuth } from '~/utils/auth';
-import ActivityFeed from './_components/ActivityFeed/ActivityFeed';
-import { searchParamsCache } from './_components/ActivityFeed/searchParamsCache';
+import { ActivityFeed } from './_components/ActivityFeed/ActivityFeed';
 import SummaryStatistics from './_components/SummaryStatistics/SummaryStatistics';
 import AnonymousRecruitmentWarning from './protocols/_components/AnonymousRecruitmentWarning';
 
-export default async function Home({
-  searchParams,
-}: {
-  searchParams: Record<string, string | string[] | undefined>;
-}) {
+export default async function Home() {
   await requireAppNotExpired();
   await requirePageAuth();
-
-  searchParamsCache.parse(searchParams);
 
   return (
     <>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
+import { Quicksand } from 'next/font/google';
+import TanstackQueryClient from '~/components/TanstackQueryClient';
 import { Toaster } from '~/components/ui/toaster';
 import '~/styles/globals.scss';
-import { Quicksand } from 'next/font/google';
 
 export const metadata = {
   title: 'Network Canvas Fresco',
@@ -17,7 +18,7 @@ function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body className={`${quicksand.className} antialiased`}>
-        {children}
+        <TanstackQueryClient>{children}</TanstackQueryClient>
         <Toaster />
       </body>
     </html>

--- a/components/TanstackQueryClient.tsx
+++ b/components/TanstackQueryClient.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+// Create a client
+const queryClient = new QueryClient();
+
+export default function TanstackQueryClient({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/components/data-table/data-table-toolbar.tsx
+++ b/components/data-table/data-table-toolbar.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import * as React from 'react';
-import Link from 'next/link';
 import type { Table } from '@tanstack/react-table';
+import { PlusCircle, Trash, X } from 'lucide-react';
+import Link from 'next/link';
+import * as React from 'react';
+import { type UrlObject } from 'url';
+import { DataTableFacetedFilter } from '~/components/data-table/data-table-faceted-filter';
 import { Button, buttonVariants } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
-import { DataTableFacetedFilter } from '~/components/data-table/data-table-faceted-filter';
 import {
   type DataTableFilterableColumn,
   type DataTableSearchableColumn,
 } from '~/lib/data-table/types';
-import { PlusCircle, Trash, X } from 'lucide-react';
 import { cn } from '~/utils/shadcn';
-import { type UrlObject } from 'url';
 
 type DataTableToolbarProps<TData> = {
   table: Table<TData>;
@@ -29,7 +29,7 @@ export function DataTableToolbar<TData>({
   newRowLink,
   deleteRowsAction,
 }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getState().columnFilters.length > 0;
+  const isFiltered = table.getState().columnFilters?.length > 0 ?? false;
   const [isPending, startTransition] = React.useTransition();
 
   return (

--- a/hooks/use-data-table.tsx
+++ b/hooks/use-data-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import {
   getCoreRowModel,
   getFacetedRowModel,
@@ -15,16 +14,14 @@ import {
   type SortingState,
   type VisibilityState,
 } from '@tanstack/react-table';
+import * as React from 'react';
 import type {
   DataTableFilterableColumn,
   DataTableSearchableColumn,
-  FilterParam,
-  PageSize,
   SortableField,
 } from '~/lib/data-table/types';
 
 import { useTableStateFromSearchParams } from '~/app/dashboard/_components/ActivityFeed/useTableStateFromSearchParams';
-import { debounce } from 'lodash';
 
 type UseDataTableProps<TData, TValue> = {
   /**
@@ -68,9 +65,9 @@ export function useDataTable<TData, TValue>({
   data,
   columns,
   pageCount, // Todo: the below should be used to filter filter/search terms before setting search params
-} // searchableColumns = [],
-// filterableColumns = [],
-: UseDataTableProps<TData, TValue>) {
+  // searchableColumns = [],
+  // filterableColumns = [],
+}: UseDataTableProps<TData, TValue>) {
   const { searchParams, setSearchParams } = useTableStateFromSearchParams();
 
   // Table states
@@ -78,7 +75,7 @@ export function useDataTable<TData, TValue>({
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    (searchParams.filterParams as ColumnFiltersState) ?? [],
+    (searchParams.filterParams as ColumnFiltersState) ?? null,
   );
 
   const [{ pageIndex, pageSize }, setPagination] =
@@ -95,39 +92,20 @@ export function useDataTable<TData, TValue>({
     [pageIndex, pageSize],
   );
 
-  const debouncedUpdateFilterParams = debounce(
-    (columnFilters: FilterParam[]) => {
-      if (!columnFilters || columnFilters.length === 0) {
-        void setSearchParams.setFilterParams(null);
-        return;
-      }
-
-      void setSearchParams.setFilterParams(columnFilters);
-      // Changing the filter params should reset the page to 1
-      // void setSearchParams.setPage(1);
-    },
-    2000,
-    {
-      trailing: true,
-      leading: false,
-    },
-  );
-
   // Sync any changes to columnFilters back to searchParams
   React.useEffect(() => {
-    // If we are resetting, skip the debounce
     if (!columnFilters || columnFilters.length === 0) {
-      void setSearchParams.setFilterParams(null);
+      void setSearchParams({
+        filterParams: null,
+      });
       return;
     }
 
-    debouncedUpdateFilterParams(columnFilters as FilterParam[]);
-
-    // Changing the filter params should reset the page to 1
-    void setSearchParams.setPage(1);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnFilters]);
+    void setSearchParams({
+      page: 1,
+      filterParams: columnFilters as { id: string; value: string | string[] }[], // Hack!
+    });
+  }, [columnFilters, setSearchParams]);
 
   React.useEffect(() => {
     setPagination({
@@ -137,11 +115,11 @@ export function useDataTable<TData, TValue>({
   }, [searchParams.page, searchParams.perPage]);
 
   React.useEffect(() => {
-    void setSearchParams.setPage(pageIndex + 1);
-    void setSearchParams.setPerPage(pageSize as PageSize);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageIndex, pageSize]);
+    void setSearchParams({
+      page: pageIndex + 1,
+      perPage: pageSize,
+    });
+  }, [pageIndex, pageSize, setSearchParams]);
 
   const [sorting, setSorting] = React.useState<SortingState>([
     {
@@ -151,10 +129,11 @@ export function useDataTable<TData, TValue>({
   ]);
 
   React.useEffect(() => {
-    void setSearchParams.setSort(sorting[0]?.desc ? 'desc' : 'asc');
-    void setSearchParams.setSortField(sorting[0]?.id as SortableField);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorting]);
+    void setSearchParams({
+      sort: sorting[0]?.desc ? 'desc' : 'asc',
+      sortField: sorting[0]?.id as SortableField,
+    });
+  }, [sorting, setSearchParams]);
 
   const dataTable = useReactTable({
     data,

--- a/lib/data-table/types.ts
+++ b/lib/data-table/types.ts
@@ -1,6 +1,5 @@
 import { type Prisma } from '@prisma/client';
 import * as z from 'zod';
-import { numberEnum } from '~/schemas/participant';
 
 export type Option = {
   label: string;
@@ -61,20 +60,9 @@ export const sortableFields = [
 export type SortableField = (typeof sortableFields)[number];
 
 export const pageSizes = [10, 20, 50, 100] as const;
-export type PageSize = (typeof pageSizes)[number];
 
 export const FilterParam = z.object({
   id: z.string(),
   value: z.union([z.string(), z.array(z.string())]),
 });
 export type FilterParam = z.infer<typeof FilterParam>;
-
-const SearchParamsSchema = z.object({
-  page: z.number(),
-  perPage: numberEnum(pageSizes),
-  sort: z.enum(sortOrder),
-  sortField: z.enum(sortableFields),
-  filterParams: z.array(FilterParam).nullable(),
-});
-
-export type SearchParams = z.infer<typeof SearchParamsSchema>;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.7",
+    "@tanstack/react-query": "^5.37.1",
     "@tanstack/react-table": "^8.16.0",
     "@types/async": "^3.2.24",
     "@uploadthing/react": "^6.5.1",
@@ -111,6 +112,7 @@
   },
   "devDependencies": {
     "@prisma/client": "^5.14.0",
+    "@tanstack/eslint-plugin-query": "^5.35.6",
     "@total-typescript/ts-reset": "^0.5.1",
     "@types/archiver": "^6.0.2",
     "@types/d3-interpolate-path": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@codaco/analytics':
         specifier: ^5.1.0
-        version: 5.1.0(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))
+        version: 5.1.0(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))
       '@codaco/protocol-validation':
         specifier: 3.0.0-alpha.4
         version: 3.0.0-alpha.4(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)
@@ -86,6 +86,9 @@ importers:
       '@tailwindcss/forms':
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
+      '@tanstack/react-query':
+        specifier: ^5.37.1
+        version: 5.37.1(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.16.0
         version: 8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -94,7 +97,7 @@ importers:
         version: 3.2.24
       '@uploadthing/react':
         specifier: ^6.5.1
-        version: 6.5.4(@uploadthing/mime-types@0.2.10)(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(react@18.3.1)(uploadthing@6.10.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))))
+        version: 6.5.4(@uploadthing/mime-types@0.2.10)(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(react@18.3.1)(uploadthing@6.10.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))))
       '@xmldom/xmldom':
         specifier: ^0.8.10
         version: 0.8.10
@@ -160,10 +163,10 @@ importers:
         version: 3.4.4
       next:
         specifier: 14.2.3
-        version: 14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
+        version: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
       nuqs:
         specifier: ^1.17.1
-        version: 1.17.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))
+        version: 1.17.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))
       ohash:
         specifier: ^1.1.3
         version: 1.1.3
@@ -253,7 +256,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
       uploadthing:
         specifier: ^6.10.1
-        version: 6.10.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
+        version: 6.10.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
       usehooks-ts:
         specifier: ^2.16.0
         version: 2.16.0(react@18.3.1)
@@ -273,6 +276,9 @@ importers:
       '@prisma/client':
         specifier: ^5.14.0
         version: 5.14.0(prisma@5.14.0)
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.35.6
+        version: 5.35.6(eslint@8.57.0)(typescript@5.4.5)
       '@total-typescript/ts-reset':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1781,6 +1787,19 @@ packages:
     resolution: {integrity: sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
+
+  '@tanstack/eslint-plugin-query@5.35.6':
+    resolution: {integrity: sha512-XhVRLsJFJMWYNzArPzy1MWSpx2BSUnc8Zof+fvsgaAnWBy9tjNXH3DFftZoNMGA8Mw1dPIdDPkEQcSku3m80Jw==}
+    peerDependencies:
+      eslint: ^8.0.0
+
+  '@tanstack/query-core@5.36.1':
+    resolution: {integrity: sha512-BteWYEPUcucEu3NBcDAgKuI4U25R9aPrHSP6YSf2NvaD2pSlIQTdqOfLRsxH9WdRYg7k0Uom35Uacb6nvbIMJg==}
+
+  '@tanstack/react-query@5.37.1':
+    resolution: {integrity: sha512-EhtBNA8GL3XFeSx6VYUjXQ96n44xe3JGKZCzBINrCYlxbZP6UwBafv7ti4eSRWc2Fy+fybQre0w17gR6lMzULA==}
+    peerDependencies:
+      react: ^18.0.0
 
   '@tanstack/react-table@8.17.3':
     resolution: {integrity: sha512-5gwg5SvPD3lNAXPuJJz1fOCEZYk9/GeBFH3w/hCgnfyszOIzwkwgp5I7Q4MJtn0WECp84b5STQUDdmvGi8m3nA==}
@@ -5887,9 +5906,9 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@codaco/analytics@5.1.0(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))':
+  '@codaco/analytics@5.1.0(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))':
     dependencies:
-      next: 14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
+      next: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
       zod: 3.23.8
 
   '@codaco/protocol-validation@3.0.0-alpha.4(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)':
@@ -7115,6 +7134,21 @@ snapshots:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))
 
+  '@tanstack/eslint-plugin-query@5.35.6(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/query-core@5.36.1': {}
+
+  '@tanstack/react-query@5.37.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.36.1
+      react: 18.3.1
+
   '@tanstack/react-table@8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/table-core': 8.17.3
@@ -7379,16 +7413,16 @@ snapshots:
 
   '@uploadthing/mime-types@0.2.10': {}
 
-  '@uploadthing/react@6.5.4(@uploadthing/mime-types@0.2.10)(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(react@18.3.1)(uploadthing@6.10.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))))':
+  '@uploadthing/react@6.5.4(@uploadthing/mime-types@0.2.10)(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(react@18.3.1)(uploadthing@6.10.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))))':
     dependencies:
       '@uploadthing/dropzone': 0.4.1(react@18.3.1)
       '@uploadthing/shared': 6.7.4(@uploadthing/mime-types@0.2.10)
       file-selector: 0.6.0
       react: 18.3.1
       tailwind-merge: 2.3.0
-      uploadthing: 6.10.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
+      uploadthing: 6.10.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5)))
     optionalDependencies:
-      next: 14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
+      next: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
     transitivePeerDependencies:
       - '@uploadthing/mime-types'
       - solid-js
@@ -9978,7 +10012,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2):
+  next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2):
     dependencies:
       '@next/env': 14.2.3
       '@swc/helpers': 0.5.5
@@ -9988,7 +10022,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.23.2)(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.24.5)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.3
       '@next/swc-darwin-x64': 14.2.3
@@ -10020,10 +10054,10 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
-  nuqs@1.17.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)):
+  nuqs@1.17.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)):
     dependencies:
       mitt: 3.0.1
-      next: 14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
+      next: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
 
   nwsapi@2.2.10: {}
 
@@ -10913,12 +10947,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.2
 
-  styled-jsx@5.1.1(@babel/core@7.23.2)(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.24.5)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
 
   sucrase@3.34.0:
     dependencies:
@@ -11214,7 +11248,7 @@ snapshots:
       escalade: 3.1.2
       picocolors: 1.0.1
 
-  uploadthing@6.10.4(next@14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))):
+  uploadthing@6.10.4(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2))(tailwindcss@3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))):
     dependencies:
       '@effect/schema': 0.66.16(effect@3.1.5)(fast-check@3.18.0)
       '@uploadthing/mime-types': 0.2.10
@@ -11224,7 +11258,7 @@ snapshots:
       fast-check: 3.18.0
       std-env: 3.7.0
     optionalDependencies:
-      next: 14.2.3(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
+      next: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.2)
       tailwindcss: 3.4.3(ts-node@10.9.1(@types/node@20.12.12)(typescript@5.4.5))
 
   uri-js@4.4.1:

--- a/queries/activityFeed.ts
+++ b/queries/activityFeed.ts
@@ -1,13 +1,10 @@
 import { unstable_cache } from 'next/cache';
-import { type SearchParams } from '~/lib/data-table/types';
-import { prisma } from '~/utils/db';
 import 'server-only';
+import type { searchParamsCache } from '~/app/dashboard/_components/ActivityFeed/SearchParams';
+import { prisma } from '~/utils/db';
 
 export const getActivities = unstable_cache(
-  async (rawSearchParams: unknown) => {
-    // const searchParams = SearchParamsSchema.parse(rawSearchParams);
-    const searchParams = rawSearchParams as SearchParams;
-
+  async (searchParams: ReturnType<typeof searchParamsCache.parse>) => {
     const { page, perPage, sort, sortField, filterParams } = searchParams;
 
     // Number of items to skip
@@ -53,5 +50,3 @@ export const getActivities = unstable_cache(
     tags: ['activityFeed'],
   },
 );
-
-export type ActivitiesFeed = ReturnType<typeof getActivities>;

--- a/schemas/participant.ts
+++ b/schemas/participant.ts
@@ -1,25 +1,6 @@
 import { z } from 'zod';
 
-export const numberEnum = <Num extends number, T extends Readonly<Num[]>>(
-  args: T,
-): z.ZodSchema<T[number]> => {
-  return z.custom<T[number]>((val: unknown) => {
-    if (typeof val !== 'number') {
-      return false;
-    }
-    if (!args.includes(val as T[number])) {
-      return false;
-    }
-    return true;
-  });
-};
-
 export const participantIdentifierSchema = z
-  .string()
-  .min(1, { message: 'Identifier cannot be empty' })
-  .max(255, { message: 'Identifier too long. Maxiumum of 255 characters.' });
-
-const participantIdSchema = z
   .string()
   .min(1, { message: 'Identifier cannot be empty' })
   .max(255, { message: 'Identifier too long. Maxiumum of 255 characters.' });


### PR DESCRIPTION
This PR implements the activity feed table as a client component with tanstack query and a single API route handler, that uses the existing query.