### PR TITLE
reimplement recruitment test section

### DIFF
--- a/app/dashboard/_components/RecruitmentTestSection.tsx
+++ b/app/dashboard/_components/RecruitmentTestSection.tsx
@@ -1,4 +1,8 @@
-import Section from '~/components/layout/Section';
+'use client';
+import type { Participant, Protocol } from '@prisma/client';
+import { type Route } from 'next';
+import { useRouter } from 'next/navigation';
+import { use, useEffect, useState } from 'react';
 import { Button } from '~/components/ui/Button';
 import {
   Select,
@@ -7,62 +11,57 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select';
-import Heading from '~/components/ui/typography/Heading';
-import Paragraph from '~/components/ui/typography/Paragraph';
-import { getProtocols } from '~/queries/protocols';
+import { type GetParticipantsReturnType } from '~/queries/participants';
+import { type GetProtocolsReturnType } from '~/queries/protocols';
+import getBaseUrl from '~/utils/getBaseUrl';
 
-export default async function RecruitmentTestSection() {
-  const protocols = await getProtocols();
+export default function RecruitmentTestSection({
+  protocolsPromise,
+  participantsPromise,
+  allowAnonymousRecruitmentPromise,
+}: {
+  protocolsPromise: GetProtocolsReturnType;
+  participantsPromise: GetParticipantsReturnType;
+  allowAnonymousRecruitmentPromise: Promise<boolean>;
+}) {
+  const protocols = use(protocolsPromise);
+  const participants = use(participantsPromise);
+  const allowAnonymousRecruitment = use(allowAnonymousRecruitmentPromise);
 
-  // const { data: protocolData, isLoading: isLoadingProtocols } =
-  //   api.protocol.get.all.useQuery();
-  // const [selectedProtocol, setSelectedProtocol] = useState<Protocol>();
-  // const [selectedParticipant, setSelectedParticipant] = useState<Participant>();
+  const [selectedProtocol, setSelectedProtocol] = useState<Protocol>();
+  const [selectedParticipant, setSelectedParticipant] = useState<Participant>();
 
-  // const { data: participants, isLoading: isLoadingParticipants } =
-  //   api.participant.get.all.useQuery();
+  const router = useRouter();
 
-  // const { data: allowAnonymousRecruitment } =
-  //   api.appSettings.getAnonymousRecruitmentStatus.useQuery();
+  useEffect(() => {
+    if (allowAnonymousRecruitment) {
+      setSelectedParticipant(undefined);
+    }
+  }, [allowAnonymousRecruitment]);
 
-  // useEffect(() => {
-  //   if (protocolData) {
-  //     setProtocols(protocolData);
-  //   }
-  // }, [protocolData]);
+  const buttonDisabled =
+    !selectedProtocol || (!allowAnonymousRecruitment && !selectedParticipant);
 
-  // useEffect(() => {
-  //   if (allowAnonymousRecruitment) {
-  //     setSelectedParticipant(undefined);
-  //   }
-  // }, [allowAnonymousRecruitment]);
+  const getInterviewURL = (): Route => {
+    if (!selectedParticipant) {
+      return `/onboard/${selectedProtocol?.id}` as Route;
+    }
 
-  // const buttonDisabled =
-  //   !selectedProtocol || (!allowAnonymousRecruitment && !selectedParticipant);
-
-  // const getInterviewURL = (): Route => {
-  //   if (!selectedParticipant) {
-  //     return `/onboard/${selectedProtocol?.id}` as Route;
-  //   }
-
-  //   return `/onboard/${selectedProtocol?.id}/?participantIdentifier=${selectedParticipant?.identifier}` as Route;
-  // };
+    return `/onboard/${selectedProtocol?.id}/?participantIdentifier=${selectedParticipant?.identifier}` as Route;
+  };
 
   return (
-    <Section>
-      <Heading variant="h4-all-caps">Recruitment Test Section</Heading>
-      <Paragraph>This section allows you to test recruitment.</Paragraph>
+    <>
       <div className="mt-6 flex gap-4">
         <Select
-        // onValueChange={(value) => {
-        //   const protocol = protocols.find(
-        //     (protocol) => protocol.id === value,
-        //   );
+          onValueChange={(value) => {
+            const protocol = protocols.find(
+              (protocol) => protocol.id === value,
+            );
 
-        //   setSelectedProtocol(protocol);
-        // }}
-        // value={selectedProtocol?.id}
-        // disabled={isLoadingProtocols}
+            setSelectedProtocol(protocol);
+          }}
+          value={selectedProtocol?.id}
         >
           <SelectTrigger>
             <SelectValue placeholder="Select a Protocol..." />
@@ -76,56 +75,55 @@ export default async function RecruitmentTestSection() {
           </SelectContent>
         </Select>
         <Select
-        // onValueChange={(value) => {
-        //   const participant = participants?.find(
-        //     (participant) => participant.id === value,
-        //   );
+          onValueChange={(value) => {
+            const participant = participants?.find(
+              (participant) => participant.id === value,
+            );
 
-        //   setSelectedParticipant(participant);
-        // }}
-        // value={selectedParticipant?.id}
-        // disabled={isLoadingParticipants}
+            setSelectedParticipant(participant);
+          }}
+          value={selectedParticipant?.id}
         >
           <SelectTrigger>
             <SelectValue placeholder="Select a Participant..." />
           </SelectTrigger>
           <SelectContent>
-            {/* {participants?.map((participant) => (
+            {participants?.map((participant) => (
               <SelectItem key={participant.id} value={participant.id}>
                 {participant.identifier}
               </SelectItem>
-            ))} */}
+            ))}
           </SelectContent>
         </Select>
       </div>
       <div className="mt-6 flex gap-2">
         <Button
-        // disabled={buttonDisabled}
-        // onClick={() => router.push(getInterviewURL())}
+          disabled={buttonDisabled}
+          onClick={() => router.push(getInterviewURL())}
         >
           Start Interview with GET
         </Button>
         <Button
-        // disabled={buttonDisabled}
-        // onClick={async () =>
-        //   await fetch(getBaseUrl() + getInterviewURL(), {
-        //     method: 'POST',
-        //     headers: {
-        //       'Content-Type': 'application/json',
-        //     },
-        //     body: JSON.stringify({
-        //       participantIdentifier: selectedParticipant?.identifier,
-        //     }),
-        //   }).then((response) => {
-        //     if (response.redirected) {
-        //       window.location.href = response.url;
-        //     }
-        //   })
-        // }
+          disabled={buttonDisabled}
+          onClick={async () =>
+            await fetch(getBaseUrl() + getInterviewURL(), {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                participantIdentifier: selectedParticipant?.identifier,
+              }),
+            }).then((response) => {
+              if (response.redirected) {
+                window.location.href = response.url;
+              }
+            })
+          }
         >
           Start Interview with POST
         </Button>
       </div>
-    </Section>
+    </>
   );
 }

--- a/app/dashboard/_components/RecruitmentTestSectionServer.tsx
+++ b/app/dashboard/_components/RecruitmentTestSectionServer.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react';
+import Section from '~/components/layout/Section';
+import Heading from '~/components/ui/typography/Heading';
+import Paragraph from '~/components/ui/typography/Paragraph';
+import { getAnonymousRecruitmentStatus } from '~/queries/appSettings';
+import { getParticipants } from '~/queries/participants';
+import { getProtocols } from '~/queries/protocols';
+import RecruitmentTestSection from './RecruitmentTestSection';
+
+export default function RecruitmentTestSectionServer() {
+  const protocolsPromise = getProtocols();
+  const participantsPromise = getParticipants();
+  const allowAnonymousRecruitmentPromise = getAnonymousRecruitmentStatus();
+
+  return (
+    <Section>
+      <Heading variant="h4-all-caps">Recruitment Test Section</Heading>
+      <Paragraph>This section allows you to test recruitment.</Paragraph>
+      <Suspense>
+        <RecruitmentTestSection
+          protocolsPromise={protocolsPromise}
+          participantsPromise={participantsPromise}
+          allowAnonymousRecruitmentPromise={allowAnonymousRecruitmentPromise}
+        />
+      </Suspense>
+    </Section>
+  );
+}

--- a/app/dashboard/_components/RecruitmentTestSectionServer.tsx
+++ b/app/dashboard/_components/RecruitmentTestSectionServer.tsx
@@ -16,7 +16,7 @@ export default function RecruitmentTestSectionServer() {
     <Section>
       <Heading variant="h4-all-caps">Recruitment Test Section</Heading>
       <Paragraph>This section allows you to test recruitment.</Paragraph>
-      <Suspense>
+      <Suspense fallback="Loading">
         <RecruitmentTestSection
           protocolsPromise={protocolsPromise}
           participantsPromise={participantsPromise}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -10,7 +10,7 @@ import { env } from '~/env.mjs';
 import { getInstallationId, requireAppNotExpired } from '~/queries/appSettings';
 import { requirePageAuth } from '~/utils/auth';
 import AnalyticsButton from '../_components/AnalyticsButton';
-import RecruitmentTestSection from '../_components/RecruitmentTestSection';
+import RecruitmentTestSectionServer from '../_components/RecruitmentTestSectionServer';
 import ResetButton from '../_components/ResetButton';
 
 export default async function Settings() {
@@ -83,7 +83,7 @@ export default async function Settings() {
               </Paragraph>
             </SettingsSection>
             <Suspense fallback="Loading">
-              <RecruitmentTestSection />
+              <RecruitmentTestSectionServer />
             </Suspense>
           </>
         )}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -82,9 +82,7 @@ export default async function Settings() {
                 server.
               </Paragraph>
             </SettingsSection>
-            <Suspense fallback="Loading">
-              <RecruitmentTestSectionServer />
-            </Suspense>
+            <RecruitmentTestSectionServer />
           </>
         )}
       </ResponsiveContainer>


### PR DESCRIPTION
Reimplements recruitment test section. Implemented using a server component to create promises for data queries and passing those promises to a client component which uses the use hook to read the values. 