### PR TITLE
fix: node animation in NameGenerator

### DIFF
--- a/lib/interviewer/components/NodeList.js
+++ b/lib/interviewer/components/NodeList.js
@@ -1,10 +1,10 @@
 import { entityPrimaryKeyProperty } from '@codaco/shared-consts';
+import { compose } from '@reduxjs/toolkit';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { useRef, useState } from 'react';
-import { compose } from '@reduxjs/toolkit';
 import { v4 } from 'uuid';
 import { getCSSVariableAsString } from '~/lib/ui/utils/CSSVariables';
 import {
@@ -19,11 +19,8 @@ import Node from './Node';
 
 const EnhancedNode = DragSource(Node);
 
-// TODO: fix drag and drop here, I'm removing unused code for now to remove linting warnings (Mirfayz Karimov)
-
 export const NodeTransition = ({ children, delay, exit = false }) => (
   <motion.div
-    layout
     initial={{ opacity: 0, y: '3rem' }}
     animate={{ opacity: 1, y: 0, scale: 1, transition: { delay } }}
     exit={{ opacity: 0, scale: 0, transition: { duration: exit ? 0.4 : 0 } }}

--- a/lib/interviewer/components/NodeList.js
+++ b/lib/interviewer/components/NodeList.js
@@ -21,7 +21,8 @@ const EnhancedNode = DragSource(Node);
 
 export const NodeTransition = ({ children, delay, exit = false }) => (
   <motion.div
-    initial={{ opacity: 0, y: '3rem' }}
+    layout
+    initial={{ opacity: 0, y: '20%' }}
     animate={{ opacity: 1, y: 0, scale: 1, transition: { delay } }}
     exit={{ opacity: 0, scale: 0, transition: { duration: exit ? 0.4 : 0 } }}
   >

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "csvtojson": "^2.0.10",
     "d3-interpolate-path": "^2.3.0",
     "dotenv": "^16.4.5",
-    "framer-motion": "^11.1.7",
+    "framer-motion": "^11.2.6",
     "fuse.js": "^7.0.0",
     "jssha": "^3.3.1",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       framer-motion:
-        specifier: ^11.1.7
-        version: 11.2.4(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.2.6
+        version: 11.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -680,12 +680,6 @@ packages:
     peerDependencies:
       effect: ^3.1.3
       fast-check: ^3.13.2
-
-  '@emotion/is-prop-valid@0.8.8':
-    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
-
-  '@emotion/memoize@0.7.4':
-    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
   '@ericcornelissen/bash-parser@0.5.2':
     resolution: {integrity: sha512-4pIMTa1nEFfMXitv7oaNEWOdM+zpOZavesa5GaiWTgda6Zk32CFGxjUp/iIaN0PwgUW1yTq/fztSjbpE8SLGZQ==}
@@ -3059,8 +3053,8 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@11.2.4:
-    resolution: {integrity: sha512-D+EXd0lspaZijv3BJhAcSsyGz+gnvoEdnf+QWkPZdhoFzbeX/2skrH9XSVFb0osgUnCajW8x1frjhLuKwa/Reg==}
+  framer-motion@11.2.6:
+    resolution: {integrity: sha512-XUrjjBt57e5YoHQtjwc3eNchFBuHvIgN/cS8SC4oIaAn2J/0+bLanUxXizidJKZVeHJam/JrmMnPRjYMglVn5g==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0
@@ -5922,14 +5916,6 @@ snapshots:
       effect: 3.1.5
       fast-check: 3.18.0
 
-  '@emotion/is-prop-valid@0.8.8':
-    dependencies:
-      '@emotion/memoize': 0.7.4
-    optional: true
-
-  '@emotion/memoize@0.7.4':
-    optional: true
-
   '@ericcornelissen/bash-parser@0.5.2':
     dependencies:
       array-last: 1.3.0
@@ -8670,11 +8656,10 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@11.2.4(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@11.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       tslib: 2.6.2
     optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
This PR fixes node animation with the following changes:
- Updates framer-motion to the latest (`11.2.6`)
- Removes the `layout` attribute in `NodeTransition`  component

(FYI: I tried everything and the only solutions that worked were either setting `y: '20%'` rather than `y: '3rem'` or removing the `layout` attribute)

Open to any suggestions!