### PR TITLE
Fix/null column added to network

### DIFF
--- a/lib/interviewer/containers/CategoricalList/CategoricalListItem.js
+++ b/lib/interviewer/containers/CategoricalList/CategoricalListItem.js
@@ -1,16 +1,16 @@
-import React, { useState } from 'react';
-import { compose } from '@reduxjs/toolkit';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import { entityPrimaryKeyProperty } from '@codaco/shared-consts';
-import { actionCreators as sessionActions } from '../../ducks/modules/session';
-import { getEntityAttributes } from '../../ducks/modules/network';
+import { compose } from '@reduxjs/toolkit';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { connect } from 'react-redux';
 import CategoricalItem from '../../components/CategoricalItem';
+import { getEntityAttributes } from '../../ducks/modules/network';
+import { actionCreators as sessionActions } from '../../ducks/modules/session';
+import { getNodeColor, getNodeLabel } from '../../selectors/network';
+import { getSubjectType } from '../../selectors/prop';
+import { get } from '../../utils/lodash-replacements';
 import Overlay from '../Overlay';
 import OtherVariableForm from './OtherVariableForm';
-import { get } from '../../utils/lodash-replacements';
-import { getSubjectType } from '../../selectors/prop';
-import { getNodeColor, getNodeLabel } from '../../selectors/network';
 
 const formatBinDetails = (nodes, getNodeLabel) => {
   if (nodes.length === 0) {
@@ -35,7 +35,6 @@ const CategoricalListItem = (props) => {
     isExpanded,
     accentColor = null,
     activePromptVariable,
-    promptOtherVariable = null,
     bin,
     index,
     sortOrder = [],
@@ -47,7 +46,9 @@ const CategoricalListItem = (props) => {
   } = props;
 
   const isOtherVariable = !!bin.otherVariable;
-  const [otherVariableWindow, setOtherVariableWindow] = useState(otherVariableWindowInitialState);
+  const [otherVariableWindow, setOtherVariableWindow] = useState(
+    otherVariableWindowInitialState,
+  );
   const binDetails = formatBinDetails(bin.nodes, getNodeLabel);
 
   const openOtherVariableWindow = (node) => {
@@ -64,12 +65,11 @@ const CategoricalListItem = (props) => {
     });
   };
 
-  const closeOtherVariableWindow = () => setOtherVariableWindow(otherVariableWindowInitialState);
+  const closeOtherVariableWindow = () =>
+    setOtherVariableWindow(otherVariableWindowInitialState);
 
   const setNodeCategory = (node, category) => {
     const variable = bin.otherVariable || activePromptVariable;
-
-    const resetVariable = bin.otherVariable ? activePromptVariable : promptOtherVariable;
 
     // categorical requires an array, otherVariable is a string
     const value = bin.otherVariable ? category : [category];
@@ -83,9 +83,6 @@ const CategoricalListItem = (props) => {
       {},
       {
         [variable]: value,
-        // because category can now be promptVariable or
-        // otherVariable we need to reset the alternate.
-        [resetVariable]: null,
       },
       'drop',
     );
@@ -103,7 +100,9 @@ const CategoricalListItem = (props) => {
   };
 
   const handleClickItem = (node) => {
-    if (!isOtherVariable) { return; }
+    if (!isOtherVariable) {
+      return;
+    }
     openOtherVariableWindow(node);
   };
 
@@ -115,7 +114,9 @@ const CategoricalListItem = (props) => {
   };
 
   const handleExpandBin = (e) => {
-    if (e) { e.stopPropagation(); }
+    if (e) {
+      e.stopPropagation();
+    }
     onExpandBin(index);
   };
 
@@ -140,26 +141,24 @@ const CategoricalListItem = (props) => {
         sortOrder={sortOrder}
         stage={stage}
       />
-      {isOtherVariable
-        && (
-          <Overlay
-            show={otherVariableWindow.show}
-            onClose={closeOtherVariableWindow}
-            onBlur={closeOtherVariableWindow}
-          >
-            {otherVariableWindow.show
-              && (
-                <OtherVariableForm
-                  label={otherVariableWindow.label}
-                  color={otherVariableWindow.color}
-                  otherVariablePrompt={bin.otherVariablePrompt}
-                  onSubmit={handleSubmitOtherVariableForm}
-                  onCancel={closeOtherVariableWindow}
-                  initialValues={otherVariableWindow.initialValues}
-                />
-              )}
-          </Overlay>
-        )}
+      {isOtherVariable && (
+        <Overlay
+          show={otherVariableWindow.show}
+          onClose={closeOtherVariableWindow}
+          onBlur={closeOtherVariableWindow}
+        >
+          {otherVariableWindow.show && (
+            <OtherVariableForm
+              label={otherVariableWindow.label}
+              color={otherVariableWindow.color}
+              otherVariablePrompt={bin.otherVariablePrompt}
+              onSubmit={handleSubmitOtherVariableForm}
+              onCancel={closeOtherVariableWindow}
+              initialValues={otherVariableWindow.initialValues}
+            />
+          )}
+        </Overlay>
+      )}
     </div>
   );
 };
@@ -178,7 +177,6 @@ CategoricalListItem.propTypes = {
   size: PropTypes.number,
 };
 
-
 const makeMapStateToProps = () => {
   return (state, props) => {
     const type = getSubjectType(state, props);
@@ -186,16 +184,15 @@ const makeMapStateToProps = () => {
 
     return {
       getNodeLabel: getNodeLabel(state, props),
-      nodeColor: color
-    }
-  }
-}
-
+      nodeColor: color,
+    };
+  };
+};
 
 const mapDispatchToProps = {
   updateNode: sessionActions.updateNode,
 };
 
-export default compose(
-  connect(makeMapStateToProps, mapDispatchToProps),
-)(CategoricalListItem);
+export default compose(connect(makeMapStateToProps, mapDispatchToProps))(
+  CategoricalListItem,
+);

--- a/lib/interviewer/containers/CategoricalList/CategoricalListItem.js
+++ b/lib/interviewer/containers/CategoricalList/CategoricalListItem.js
@@ -35,6 +35,7 @@ const CategoricalListItem = (props) => {
     isExpanded,
     accentColor = null,
     activePromptVariable,
+    promptOtherVariable = null,
     bin,
     index,
     sortOrder = [],
@@ -71,6 +72,10 @@ const CategoricalListItem = (props) => {
   const setNodeCategory = (node, category) => {
     const variable = bin.otherVariable || activePromptVariable;
 
+    const resetVariable = bin.otherVariable
+      ? activePromptVariable
+      : promptOtherVariable;
+
     // categorical requires an array, otherVariable is a string
     const value = bin.otherVariable ? category : [category];
 
@@ -83,6 +88,8 @@ const CategoricalListItem = (props) => {
       {},
       {
         [variable]: value,
+        // reset is used to clear the variable when a node is moved to a different bin
+        ...(!!resetVariable && { [resetVariable]: null }),
       },
       'drop',
     );


### PR DESCRIPTION
On categorical bin interfaces without an other variable option, "null" was being added as a variable in the network.


This fix checks if resetVariable is truthy before adding it to the network. resetVariable exists in cases where a node is moved from a non-other bin to an other bin, or from an other bin to a non-other bin. 