### PR TITLE
Fix docker deployment related issues

### DIFF
--- a/app/(interview)/onboard/[protocolId]/route.ts
+++ b/app/(interview)/onboard/[protocolId]/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import { createInterview } from '~/actions/interviews';
+import { env } from '~/env';
 import trackEvent from '~/lib/analytics';
 import { getLimitInterviewsStatus } from '~/queries/appSettings';
 
@@ -11,7 +12,7 @@ const handler = async (
   { params }: { params: { protocolId: string } },
 ) => {
   const protocolId = params.protocolId; // From route segment
-  const url = req.nextUrl.clone();
+  const url = env.PUBLIC_URL ? new URL(env.PUBLIC_URL) : req.nextUrl.clone();
 
   // If no protocol ID is provided, redirect to the error page.
   if (!protocolId || protocolId === 'undefined') {

--- a/app/(interview)/onboard/[protocolId]/route.ts
+++ b/app/(interview)/onboard/[protocolId]/route.ts
@@ -12,7 +12,12 @@ const handler = async (
   { params }: { params: { protocolId: string } },
 ) => {
   const protocolId = params.protocolId; // From route segment
-  const url = env.PUBLIC_URL ? new URL(env.PUBLIC_URL) : req.nextUrl.clone();
+
+  // when deployed via docker `req.url` and `req.nextUrl`
+  // shows Docker Container ID instead of real host
+  // issue: https://github.com/vercel/next.js/issues/65568
+  // workaround: use `env.PUBLIC_URL` to get the correct url
+  const url = new URL(env.PUBLIC_URL ?? req.nextUrl.clone());
 
   // If no protocol ID is provided, redirect to the error page.
   if (!protocolId || protocolId === 'undefined') {

--- a/app/api/uploadthing/route.ts
+++ b/app/api/uploadthing/route.ts
@@ -6,9 +6,10 @@ import { ourFileRouter } from './core';
 export const { GET, POST } = createRouteHandler({
   router: ourFileRouter,
   config: {
-    callbackUrl:
-      env.NODE_ENV === 'production' && env.PUBLIC_URL
-        ? env.PUBLIC_URL + '/api/uploadthing'
-        : undefined,
+    // The URL to where the route handler is hosted
+    // UploadThing attempts to automatically detect this value based on the request URL and headers
+    // However, the automatic detection fails in docker deployments
+    // docs: https://docs.uploadthing.com/api-reference/server#config
+    callbackUrl: env.PUBLIC_URL && `${env.PUBLIC_URL}/api/uploadthing`,
   },
 });

--- a/app/api/uploadthing/route.ts
+++ b/app/api/uploadthing/route.ts
@@ -1,7 +1,14 @@
 import { createRouteHandler } from 'uploadthing/next';
+import { env } from '~/env';
 import { ourFileRouter } from './core';
 
 // Export routes for Next App Router
 export const { GET, POST } = createRouteHandler({
   router: ourFileRouter,
+  config: {
+    callbackUrl:
+      env.NODE_ENV === 'production' && env.PUBLIC_URL
+        ? env.PUBLIC_URL + '/api/uploadthing'
+        : undefined,
+  },
 });


### PR DESCRIPTION
This PR fixes the following issues related to docker deployment:

- Fix uploading protocol by setting `config.callbackUrl` for UploadThing router if the app is running in production & `PUBLIC_URL` environment is set to the domain name of the app
- Fix the anonymous participation URL feature by setting the `url` to `new URL(env.PUBLIC_URL)` in `/onboard/protocolId` route if present