### PR TITLE
Fix/fresh setup migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY prisma ./prisma
 
 # Copy package.json and lockfile, along with postinstall script
-COPY package.json pnpm-lock.yaml* postinstall.js migrate-and-start.sh setup-database.js ./
+COPY package.json pnpm-lock.yaml* postinstall.js migrate-and-start.sh setup-database.js initialize.js ./
 
 # # Install pnpm and install dependencies
 RUN corepack enable pnpm && pnpm i --frozen-lockfile
@@ -55,6 +55,7 @@ RUN chown nextjs:nodejs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/initialize.js ./
 COPY --from=builder --chown=nextjs:nodejs /app/setup-database.js ./
 COPY --from=builder --chown=nextjs:nodejs /app/migrate-and-start.sh ./
 COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma

--- a/initialize.js
+++ b/initialize.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+/** 
+ * We set the the initializedAt key here, because this script is run when the
+ * app is first deployed.
+**/
+async function setInitializedAt() {
+  // Check if app is already initialized
+  const initializedAt = await prisma.appSettings.findUnique({
+    where: {
+      key: 'initializedAt'
+    }
+  });
+
+  if (initializedAt) {
+    console.log('App already initialized. Skipping.');
+    return;
+  }
+
+  const now = new Date().toISOString();
+
+  console.log(`Setting initializedAt to ${now}.`);
+
+  await prisma.appSettings.upsert({
+    where: {
+      key: 'initializedAt',
+    },
+    // No update emulates findOrCreate
+    update: {},
+    create: {
+      key: 'initializedAt',
+      value: now
+    }
+  });
+}
+
+// Self executing function
+(async () => {
+  await setInitializedAt();
+})();

--- a/migrate-and-start.sh
+++ b/migrate-and-start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 node setup-database.js
+node initialize.js
 node server.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ts-lint": "SKIP_ENV_VALIDATION=true tsc --noEmit --incremental",
     "ts-lint:watch": "SKIP_ENV_VALIDATION=true tsc --noEmit --incremental --watch",
     "start": "next start",
-    "vercel-build": "node ./setup-database.js && next build",
+    "vercel-build": "node ./setup-database.js && node ./initialize.js && next build",
     "knip": "knip",
     "test": "vitest",
     "load-test": "docker run -i grafana/k6 run - <load-test.js"

--- a/setup-database.js
+++ b/setup-database.js
@@ -1,8 +1,37 @@
 /* eslint-disable no-console */
 import { PrismaClient } from '@prisma/client';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 
 const prisma = new PrismaClient();
+
+function checkForNeededMigrations() {
+  const command = 'npx';
+  const args = [
+    'prisma', 'migrate', 'diff',
+    '--to-schema-datasource', './prisma/schema.prisma',
+    '--from-schema-datamodel', './prisma/schema.prisma',
+    '--exit-code'
+  ];
+
+  const result = spawnSync(command, args, { encoding: 'utf-8' });
+
+  if (result.error) {
+    console.error('Failed to run command:', result.error);
+    return false;
+  }
+
+  // Handling the exit code
+  if (result.status === 0) {
+    console.log('No differences between DB and schema detected.');
+    return false;
+  } else if (result.status === 2) {
+    console.log('There are differences between the schemas.');
+    return true;
+  } else if (result.status === 1) {
+    console.log('An error occurred.');
+    return false;
+  }
+}
 
 async function handleMigrations() {
   /**
@@ -30,8 +59,15 @@ async function handleMigrations() {
       execSync('npx prisma migrate resolve --applied 0_init', { stdio: 'inherit' });
     }
 
-    console.log('Running: prisma migrate deploy');
-    execSync('npx prisma migrate deploy', { stdio: 'inherit' });
+    // Determine if there are any migrations to run, by comparing the local schema with the database schema using prisma migrate diff
+    const needsMigrations = checkForNeededMigrations();
+
+    if (needsMigrations) {
+      console.log('Migrations needed! Running: prisma migrate dev');
+      execSync('npx prisma migrate dev', { stdio: 'inherit' });
+    } else {
+      console.log('No migrations needed.');
+    }
   } catch (error) {
     console.error('Error during migration process:', error);
     process.exit(1);

--- a/setup-database.js
+++ b/setup-database.js
@@ -63,8 +63,8 @@ async function handleMigrations() {
     const needsMigrations = checkForNeededMigrations();
 
     if (needsMigrations) {
-      console.log('Migrations needed! Running: prisma migrate dev');
-      execSync('npx prisma migrate dev', { stdio: 'inherit' });
+      console.log('Migrations needed! Running: prisma migrate deploy');
+      execSync('npx prisma migrate deploy', { stdio: 'inherit' });
     } else {
       console.log('No migrations needed.');
     }

--- a/setup-database.js
+++ b/setup-database.js
@@ -76,26 +76,7 @@ async function handleMigrations() {
   }
 }
 
-/** 
- * We set the the initializedAt key here, because this script is run when the
- * app is first deployed.
-**/
-async function seedInitialisedAt() {
-  await prisma.appSettings.upsert({
-    where: {
-      key: 'initializedAt',
-    },
-    // No update emulates findOrCreate
-    update: {},
-    create: {
-      key: 'initializedAt',
-      value: new Date().toISOString()
-    }
-  });
-}
 
-// Self executing function
 (async () => {
   await handleMigrations();
-  await seedInitialisedAt();
 })();


### PR DESCRIPTION
This PR is an attempt to deal with some issues relating to fresh installs. 

Essentially the migration process we have now will fail for someone deploying the app for the first time with v2.0.0. This is because the database schema will be the 2.0.0 schema (with the changes to AppSettings), but _without_ the migrations table. This in turn will trigger the migrations to run, including the 2.0.0 migration, which will fail because the table structure already exists.

The solution I have come up with is to use `prisma migrate diff` to calculate if the current database schema differs from the schema file, and to use this to determine if `prisma migrate dev` should be run. This seems to work.

I had to separate out the seeding of the initializedAt key, because the underlying database schema might have changed _after_ the prisma client was initialized. I could also have dynamically imported it a second time, perhaps.

Todo: test _all_ update scenarios thoroughly!