### PR TITLE
Fix: Semantic versioning logic

### DIFF
--- a/components/VersionSection.tsx
+++ b/components/VersionSection.tsx
@@ -8,42 +8,11 @@ import { env } from '~/env';
 import trackEvent from '~/lib/analytics';
 import { getInstallationId } from '~/queries/appSettings';
 import { ensureError } from '~/utils/ensureError';
+import { getSemverUpdateType, semverSchema } from '~/utils/semVer';
 import SettingsSection from './layout/SettingsSection';
 import { Button } from './ui/Button';
 import Heading from './ui/typography/Heading';
 import Paragraph from './ui/typography/Paragraph';
-
-const semverSchema = z
-  .string()
-  .regex(
-    /^v(\d+)\.(\d+)\.(\d+)$/,
-    "Invalid version format. Expected format is 'v1.2.3'.",
-  )
-  .transform((version) => {
-    const [, major, minor, patch] = version.match(
-      /^v(\d+)\.(\d+)\.(\d+)$/,
-    ) as string[];
-
-    if (!major || !minor || !patch) {
-      throw new Error('Invalid version format');
-    }
-
-    // Convert version parts to numbers
-    const majorNum = parseInt(major, 10);
-    const minorNum = parseInt(minor, 10);
-    const patchNum = parseInt(patch, 10);
-
-    return {
-      major: majorNum,
-      minor: minorNum,
-      patch: patchNum,
-      toString() {
-        return `v${majorNum}.${minorNum}.${patchNum}`;
-      },
-    };
-  });
-
-type SemVer = z.infer<typeof semverSchema>;
 
 const GithubApiResponseSchema = z
   .object({
@@ -57,22 +26,6 @@ const GithubApiResponseSchema = z
     releaseNotes: value.body,
     releaseUrl: value.html_url,
   }));
-
-function getSemverUpdateType(currentVersion: SemVer, newVersion: SemVer) {
-  if (currentVersion.major < newVersion.major) {
-    return 'major';
-  }
-
-  if (currentVersion.minor < newVersion.minor) {
-    return 'minor';
-  }
-
-  if (currentVersion.patch < newVersion.patch) {
-    return 'patch';
-  }
-
-  return null;
-}
 
 async function checkForUpdate() {
   unstable_noStore();

--- a/utils/semVer.test.ts
+++ b/utils/semVer.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { getSemverUpdateType } from '~/utils/semVer';
+
+const currentVersion = { major: 1, minor: 2, patch: 3 };
+
+describe('getSemverUpdateType', () => {
+  it('returns "major" when new major version is higher', () => {
+    expect(
+      getSemverUpdateType(currentVersion, { major: 2, minor: 0, patch: 0 }),
+    ).toBe('major');
+    expect(
+      getSemverUpdateType(currentVersion, { major: 2, minor: 2, patch: 3 }),
+    ).toBe('major');
+  });
+
+  it('returns "minor" when major is the same and new minor version is higher', () => {
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 3, patch: 0 }),
+    ).toBe('minor');
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 3, patch: 3 }),
+    ).toBe('minor');
+  });
+
+  it('returns "patch" when major and minor are the same and new patch version is higher', () => {
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 2, patch: 4 }),
+    ).toBe('patch');
+  });
+
+  it('returns null when versions are identical', () => {
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 2, patch: 3 }),
+    ).toBe(null);
+  });
+
+  it('returns null when new version is lower than current version', () => {
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 2, patch: 2 }),
+    ).toBe(null);
+    expect(
+      getSemverUpdateType(currentVersion, { major: 1, minor: 1, patch: 3 }),
+    ).toBe(null);
+    expect(
+      getSemverUpdateType(currentVersion, { major: 0, minor: 9, patch: 5 }),
+    ).toBe(null);
+  });
+
+  it('returns correct type when versions differ across all parts', () => {
+    // Major is higher
+    expect(
+      getSemverUpdateType(
+        { major: 1, minor: 0, patch: 0 },
+        { major: 2, minor: 1, patch: 1 },
+      ),
+    ).toBe('major');
+    // Minor is higher
+    expect(
+      getSemverUpdateType(
+        { major: 1, minor: 1, patch: 0 },
+        { major: 1, minor: 2, patch: 0 },
+      ),
+    ).toBe('minor');
+    // Patch is higher
+    expect(
+      getSemverUpdateType(
+        { major: 1, minor: 2, patch: 3 },
+        { major: 1, minor: 2, patch: 4 },
+      ),
+    ).toBe('patch');
+  });
+});

--- a/utils/semVer.ts
+++ b/utils/semVer.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+export const semverSchema = z
+  .string()
+  .regex(
+    /^v(\d+)\.(\d+)\.(\d+)$/,
+    "Invalid version format. Expected format is 'v1.2.3'.",
+  )
+  .transform((version) => {
+    const [, major, minor, patch] = version.match(
+      /^v(\d+)\.(\d+)\.(\d+)$/,
+    ) as string[];
+
+    if (!major || !minor || !patch) {
+      throw new Error('Invalid version format');
+    }
+
+    // Convert version parts to numbers
+    const majorNum = parseInt(major, 10);
+    const minorNum = parseInt(minor, 10);
+    const patchNum = parseInt(patch, 10);
+
+    return {
+      major: majorNum,
+      minor: minorNum,
+      patch: patchNum,
+      toString() {
+        return `v${majorNum}.${minorNum}.${patchNum}`;
+      },
+    };
+  });
+
+export type SemVer = z.infer<typeof semverSchema>;
+
+export function getSemverUpdateType(
+  currentVersion: SemVer,
+  newVersion: SemVer,
+): 'major' | 'minor' | 'patch' | null {
+  // early return if versions are identical
+  if (currentVersion === newVersion) {
+    return null;
+  }
+
+  if (newVersion.major > currentVersion.major) {
+    return 'major';
+  }
+
+  if (newVersion.major === currentVersion.major) {
+    if (newVersion.minor > currentVersion.minor) {
+      return 'minor';
+    }
+
+    if (newVersion.minor === currentVersion.minor) {
+      if (newVersion.patch > currentVersion.patch) {
+        return 'patch';
+      }
+    }
+  }
+
+  // If we reach this point, we know the current version is higher than the new version
+  return null;
+}


### PR DESCRIPTION
Fixes bug where incorrect update type was returned when current version is higher than new version. Adds tests to cover logic.

Todo:
- [ ] bump version and generate release notes