### PR TITLE
Fix: Text color on destructive alerts

### DIFF
--- a/components/ui/Alert.tsx
+++ b/components/ui/Alert.tsx
@@ -14,7 +14,7 @@ const alertVariants = cva(
         default: '',
         info: 'border-info bg-info/10 [--link:var(--info)] [&>svg]:text-info',
         destructive:
-          'border-destructive bg-destructive/5 text-destructive-foreground dark:border-destructive [&>svg]:text-destructive [--link:var(--destructive)]',
+          'border-destructive bg-destructive/5 text-destructive dark:border-destructive [&>svg]:text-destructive [--link:var(--destructive)]',
         success:
           'border-success bg-success/10 text-success-foreground [&>svg]:text-success-foreground [--link:var(--success-foreground)]',
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fresco",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",


### PR DESCRIPTION
### Previous: 
<img width="532" alt="Previous destructive alert" src="https://github.com/user-attachments/assets/0671df04-444d-4d9b-9916-75c30101e84a">

### Fixed:  
<img width="524" alt="Fixed destructive alert" src="https://github.com/user-attachments/assets/65b7416c-b953-4dd7-8c44-80c1b09520db">

Todo: 
- [x] release notes
