### PR TITLE
fix graphml export

### DIFF
--- a/lib/network-exporters/formatters/graphml/__tests__/createGraphML.test.js
+++ b/lib/network-exporters/formatters/graphml/__tests__/createGraphML.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { ncUUIDProperty } from '@codaco/shared-consts';
-import { DOMParser, MIME_TYPE } from '@xmldom/xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   mockCodebook,
@@ -23,7 +23,7 @@ const buildXML = (...args) => {
   }
 
   const parser = new DOMParser();
-  const result = parser.parseFromString(xmlString, MIME_TYPE.XML_APPLICATION);
+  const result = parser.parseFromString(xmlString, 'text/xml');
   return result;
 };
 

--- a/lib/network-exporters/formatters/graphml/createGraphML.js
+++ b/lib/network-exporters/formatters/graphml/createGraphML.js
@@ -24,7 +24,7 @@ import {
   sessionProperty,
   sessionStartTimeProperty,
 } from '@codaco/shared-consts';
-import dom, { MIME_TYPE } from '@xmldom/xmldom';
+import dom from '@xmldom/xmldom';
 import {
   getAttributePropertyFromCodebook,
   getEntityAttributes,
@@ -110,7 +110,7 @@ const setUpXml = (exportOptions, sessionVariables) => {
   )}${xmlFooter}`;
   return new globalContext.DOMParser().parseFromString(
     graphMLOutline,
-    MIME_TYPE.XML_APPLICATION,
+    'text/xml',
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fresco",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",
@@ -47,7 +47,7 @@
     "@reduxjs/toolkit": "^1.9.7",
     "@tanstack/react-table": "^8.20.6",
     "@uploadthing/react": "^7.1.5",
-    "@xmldom/xmldom": "^0.9.6",
+    "@xmldom/xmldom": "^0.8.10",
     "animejs": "^2.2.0",
     "archiver": "^7.0.1",
     "async": "^3.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^7.1.5
         version: 7.1.5(next@14.2.23(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.83.4))(react@18.3.1)(uploadthing@7.4.4(next@14.2.23(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.83.4))(tailwindcss@4.0.0-beta.9))
       '@xmldom/xmldom':
-        specifier: ^0.9.6
-        version: 0.9.7
+        specifier: ^0.8.10
+        version: 0.8.10
       animejs:
         specifier: ^2.2.0
         version: 2.2.0
@@ -2253,9 +2253,9 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  '@xmldom/xmldom@0.9.7':
-    resolution: {integrity: sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -7677,7 +7677,7 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
-  '@xmldom/xmldom@0.9.7': {}
+  '@xmldom/xmldom@0.8.10': {}
 
   abort-controller@3.0.0:
     dependencies:


### PR DESCRIPTION
GraphML export was broken by the update to xmldom 0.9.x. This is because this new version enforces stricter checks on the document, which mean that it is incompatible with our current system of building the document piece by piece using streaming.

The new approach _does_ work with #204, but this requires greater integration with the type changes in #226. 