### PR TITLE
Improve video on safari

### DIFF
--- a/lib/interviewer/components/Video.js
+++ b/lib/interviewer/components/Video.js
@@ -1,6 +1,6 @@
-import { useRef, useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { Loader2 } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { useEffect, useRef, useState } from 'react';
 
 const Video = (props) => {
   const {
@@ -50,12 +50,11 @@ const Video = (props) => {
       <video
         {...rest}
         ref={video}
-        src={url}
         playsInline
         onClick={handleClick}
         onCanPlay={handleVideoLoaded}
-
       >
+        <source src={url} type='video/mp4' />
         {description}
       </video>
     </>


### PR DESCRIPTION
This PR attempts to address browser incompatibility issues with video formats by including a `<source> `tag.