### PR TITLE
Extract preview url from comment and pass to tests in env

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -20,8 +20,9 @@ jobs:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       - name: Extract URL from comment
         id: extract-url
+        env:
+          COMMENT: ${{ github.event.comment.body }}
         run: |
-          COMMENT="${{ github.event.comment.body }}"
           URL=$(echo "$COMMENT" | grep -o 'https://[^ ]*' | head -1)
           echo "preview_url=$URL" >> $GITHUB_OUTPUT
       - name: Comment action started

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -18,6 +18,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Extract URL from comment
+        id: extract-url
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          URL=$(echo "$COMMENT" | grep -o 'https://[^ ]*' | head -1)
+          echo "preview_url=$URL" >> $GITHUB_OUTPUT
       - name: Comment action started
         uses: thollander/actions-comment-pull-request@v3
         with:
@@ -32,6 +38,9 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright update snapshots
         run: pnpm exec playwright test --update-snapshots
+        env:
+          E2E_UPLOADTHING_TOKEN: ${{ secrets.E2E_UPLOADTHING_TOKEN }}
+          BASE_URL: ${{ steps.extract-url.outputs.preview_url }}
       - name: Commit and push updated snapshots
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for updating snapshots. The changes focus on extracting a URL from a comment and using it in the Playwright snapshot update process.

Key changes:

Workflow enhancements:

* [`.github/workflows/update-snapshots.yml`](diffhunk://#diff-4b6fce1c311539adb4f9a4a32423b3bba8a271508a4aeaf13b6db0dc26f828dcR21-R27): Added a step to extract the preview URL from a comment and store it in the GitHub output.
* [`.github/workflows/update-snapshots.yml`](diffhunk://#diff-4b6fce1c311539adb4f9a4a32423b3bba8a271508a4aeaf13b6db0dc26f828dcR42-R44): Updated the Playwright snapshot update step to include environment variables for `E2E_UPLOADTHING_TOKEN` and the extracted `BASE_URL`.