### PR TITLE
Fix form skip logic

### DIFF
--- a/app/(interview)/interview/_components/ServerSync.tsx
+++ b/app/(interview)/interview/_components/ServerSync.tsx
@@ -5,7 +5,7 @@ import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { SyncInterviewType } from '~/actions/interviews';
 import usePrevious from '~/hooks/usePrevious';
-import { getActiveSession } from '~/lib/interviewer/selectors/session';
+import { getActiveSession } from '~/lib/interviewer/selectors/shared';
 
 // The job of ServerSync is to listen to actions in the redux store, and to sync
 // data with the server.

--- a/lib/interviewer/containers/ProtocolScreen.tsx
+++ b/lib/interviewer/containers/ProtocolScreen.tsx
@@ -145,7 +145,11 @@ export default function ProtocolScreen() {
       await animate(scope.current, { y: '-100vh' }, animationOptions);
       // If the result is true or 'FORCE' we can reset the function here:
       registerBeforeNext(null);
-      dispatch(sessionActions.updateStage('forward') as unknown as AnyAction);
+      dispatch(
+        sessionActions.updateStage(
+          nextValidStageIndexRef.current,
+        ) as unknown as AnyAction,
+      );
     })();
 
     setForceNavigationDisabled(false);
@@ -185,7 +189,11 @@ export default function ProtocolScreen() {
       // from this point on we are definitely navigating, so set up the animation
       await animate(scope.current, { y: '100vh' }, animationOptions);
       registerBeforeNext(null);
-      dispatch(sessionActions.updateStage('backward') as unknown as AnyAction);
+      dispatch(
+        sessionActions.updateStage(
+          previousValidStageIndexRef.current,
+        ) as unknown as AnyAction,
+      );
     })();
 
     setForceNavigationDisabled(false);
@@ -225,7 +233,11 @@ export default function ProtocolScreen() {
       );
       // This should always return a valid stage, because we know that the
       // first stage is always valid.
-      dispatch(sessionActions.updateStage('backward') as unknown as AnyAction);
+      dispatch(
+        sessionActions.updateStage(
+          previousValidStageIndexRef.current,
+        ) as unknown as AnyAction,
+      );
     }
   }, [dispatch, isCurrentStepValid, previousValidStageIndex]);
 

--- a/lib/interviewer/containers/ProtocolScreen.tsx
+++ b/lib/interviewer/containers/ProtocolScreen.tsx
@@ -72,6 +72,17 @@ export default function ProtocolScreen() {
   const prevCurrentStep = usePrevious(currentStep);
   const { nextValidStageIndex, previousValidStageIndex, isCurrentStepValid } =
     useSelector(getNavigableStages);
+  const nextValidStageIndexRef = useRef(nextValidStageIndex);
+  const previousValidStageIndexRef = useRef(previousValidStageIndex);
+
+  // update the ref when the value from the selector changes
+  useEffect(() => {
+    nextValidStageIndexRef.current = nextValidStageIndex;
+  }, [nextValidStageIndex]);
+
+  useEffect(() => {
+    previousValidStageIndexRef.current = previousValidStageIndex;
+  }, [previousValidStageIndex]);
 
   const [progress, setProgress] = useState(
     makeFakeSessionProgress(currentStep, promptIndex),
@@ -130,7 +141,7 @@ export default function ProtocolScreen() {
       }
 
       // from this point on we are definitely navigating, so set up the animation
-      setProgress(makeFakeSessionProgress(nextValidStageIndex, 0));
+      setProgress(makeFakeSessionProgress(nextValidStageIndexRef.current, 0));
       await animate(scope.current, { y: '-100vh' }, animationOptions);
       // If the result is true or 'FORCE' we can reset the function here:
       registerBeforeNext(null);
@@ -141,7 +152,7 @@ export default function ProtocolScreen() {
   }, [
     isLastPrompt,
     makeFakeSessionProgress,
-    nextValidStageIndex,
+    nextValidStageIndexRef,
     animate,
     scope,
     registerBeforeNext,
@@ -167,7 +178,9 @@ export default function ProtocolScreen() {
         return;
       }
 
-      setProgress(makeFakeSessionProgress(previousValidStageIndex, 0));
+      setProgress(
+        makeFakeSessionProgress(previousValidStageIndexRef.current, 0),
+      );
 
       // from this point on we are definitely navigating, so set up the animation
       await animate(scope.current, { y: '100vh' }, animationOptions);
@@ -179,7 +192,7 @@ export default function ProtocolScreen() {
   }, [
     isFirstPrompt,
     makeFakeSessionProgress,
-    previousValidStageIndex,
+    previousValidStageIndexRef,
     animate,
     scope,
     registerBeforeNext,

--- a/lib/interviewer/ducks/modules/session.js
+++ b/lib/interviewer/ducks/modules/session.js
@@ -481,9 +481,6 @@ const updateStage = (direction) => (dispatch, getState) => {
   const { nextValidStageIndex, previousValidStageIndex } =
     getNavigableStages(state);
 
-  // eslint-disable-next-line no-console
-  console.log('nextValidStageIndex', nextValidStageIndex);
-
   const stage =
     direction === 'forward' ? nextValidStageIndex : previousValidStageIndex;
 

--- a/lib/interviewer/ducks/modules/session.js
+++ b/lib/interviewer/ducks/modules/session.js
@@ -2,7 +2,6 @@ import { entityPrimaryKeyProperty } from '@codaco/shared-consts';
 import { omit } from 'es-toolkit';
 import { has } from 'es-toolkit/compat';
 import { v4 as uuid } from 'uuid';
-import { getNavigableStages } from '../../selectors/skip-logic';
 import { actionTypes as installedProtocolsActionTypes } from './installedProtocols';
 import networkReducer, {
   actionTypes as networkActionTypes,
@@ -475,19 +474,14 @@ const updatePrompt = (promptIndex) => (dispatch, getState) => {
   });
 };
 
-const updateStage = (direction) => (dispatch, getState) => {
+const updateStage = (currentStep) => (dispatch, getState) => {
   const state = getState();
   const sessionId = state.activeSessionId;
-  const { nextValidStageIndex, previousValidStageIndex } =
-    getNavigableStages(state);
-
-  const stage =
-    direction === 'forward' ? nextValidStageIndex : previousValidStageIndex;
 
   dispatch({
     type: UPDATE_STAGE,
     sessionId,
-    currentStep: stage,
+    currentStep,
   });
 };
 

--- a/lib/interviewer/ducks/modules/session.js
+++ b/lib/interviewer/ducks/modules/session.js
@@ -2,6 +2,7 @@ import { entityPrimaryKeyProperty } from '@codaco/shared-consts';
 import { omit } from 'es-toolkit';
 import { has } from 'es-toolkit/compat';
 import { v4 as uuid } from 'uuid';
+import { getNavigableStages } from '../../selectors/skip-logic';
 import { actionTypes as installedProtocolsActionTypes } from './installedProtocols';
 import networkReducer, {
   actionTypes as networkActionTypes,
@@ -474,14 +475,22 @@ const updatePrompt = (promptIndex) => (dispatch, getState) => {
   });
 };
 
-const updateStage = (currentStep) => (dispatch, getState) => {
+const updateStage = (direction) => (dispatch, getState) => {
   const state = getState();
   const sessionId = state.activeSessionId;
+  const { nextValidStageIndex, previousValidStageIndex } =
+    getNavigableStages(state);
+
+  // eslint-disable-next-line no-console
+  console.log('nextValidStageIndex', nextValidStageIndex);
+
+  const stage =
+    direction === 'forward' ? nextValidStageIndex : previousValidStageIndex;
 
   dispatch({
     type: UPDATE_STAGE,
     sessionId,
-    currentStep,
+    currentStep: stage,
   });
 };
 

--- a/lib/interviewer/hooks/useExternalData.js
+++ b/lib/interviewer/hooks/useExternalData.js
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getVariableTypeReplacements } from '../containers/withExternalData';
 import { getAssetManifest, getProtocolCodebook } from '../selectors/protocol';
-import { getActiveSession } from '../selectors/session';
+import { getActiveSession } from '../selectors/shared';
 import getParentKeyByNameValue from '../utils/getParentKeyByNameValue';
 import loadExternalData from '../utils/loadExternalData';
 

--- a/lib/interviewer/selectors/network.ts
+++ b/lib/interviewer/selectors/network.ts
@@ -16,7 +16,7 @@ import customFilter from '~/lib/network-query/filter';
 import type { RootState } from '../store';
 import { getStageSubject, getSubjectType } from './prop';
 import { getProtocolCodebook } from './protocol';
-import { getActiveSession } from './session';
+import { getActiveSession } from './shared';
 import { createDeepEqualSelector } from './utils';
 
 export const getNetwork = createSelector(

--- a/lib/interviewer/selectors/protocol.js
+++ b/lib/interviewer/selectors/protocol.js
@@ -2,6 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import { get } from 'es-toolkit/compat';
 import { v4 as uuid } from 'uuid';
 import { getStageSubject } from './prop';
+import { getActiveSession } from './shared';
 
 const DefaultFinishStage = {
   // `id` is used as component key; must be unique from user input
@@ -9,9 +10,6 @@ const DefaultFinishStage = {
   type: 'FinishSession',
   label: 'Finish Interview',
 };
-
-const getActiveSession = (state) =>
-  state.activeSessionId && state.sessions[state.activeSessionId];
 
 const getInstalledProtocols = (state) => state.installedProtocols;
 

--- a/lib/interviewer/selectors/session.ts
+++ b/lib/interviewer/selectors/session.ts
@@ -1,19 +1,7 @@
 import type { Stage } from '@codaco/shared-consts';
-import { getProtocolStages } from './protocol';
 import { createSelector } from '@reduxjs/toolkit';
-import type { RootState } from '../store';
-
-const getActiveSessionId = (state: RootState) => state.activeSessionId;
-
-const getSessions = (state: RootState) => state.sessions;
-
-export const getActiveSession = createSelector(
-  getActiveSessionId,
-  getSessions,
-  (activeSessionId, sessions) => {
-    return sessions[activeSessionId]!;
-  },
-);
+import { getProtocolStages } from './protocol';
+import { getActiveSession } from './shared';
 
 export const getStageIndex = createSelector(getActiveSession, (session) => {
   return session.currentStep;

--- a/lib/interviewer/selectors/session.ts
+++ b/lib/interviewer/selectors/session.ts
@@ -1,11 +1,7 @@
 import type { Stage } from '@codaco/shared-consts';
 import { createSelector } from '@reduxjs/toolkit';
 import { getProtocolStages } from './protocol';
-import { getActiveSession } from './shared';
-
-export const getStageIndex = createSelector(getActiveSession, (session) => {
-  return session.currentStep;
-});
+import { getActiveSession, getStageIndex } from './shared';
 
 // Stage stage is temporary storage for stages used by TieStrengthCensus and DyadCensus
 export const getStageMetadata = createSelector(

--- a/lib/interviewer/selectors/shared.ts
+++ b/lib/interviewer/selectors/shared.ts
@@ -1,0 +1,18 @@
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+
+const getActiveSessionId = (state: RootState) => state.activeSessionId;
+
+const getSessions = (state: RootState) => state.sessions;
+
+export const getActiveSession = createSelector(
+  getActiveSessionId,
+  getSessions,
+  (activeSessionId, sessions) => {
+    return sessions[activeSessionId]!;
+  },
+);
+
+export const getStageIndex = createSelector(getActiveSession, (session) => {
+  return session.currentStep;
+});

--- a/lib/interviewer/selectors/skip-logic.ts
+++ b/lib/interviewer/selectors/skip-logic.ts
@@ -1,10 +1,10 @@
-import getQuery from '~/lib/network-query/query';
-import { getProtocolStages } from './protocol';
-import { getNetwork } from './network';
-import { SkipLogicAction } from '../protocol-consts';
-import { createSelector } from '@reduxjs/toolkit';
 import type { NcNetwork, SkipDefinition, Stage } from '@codaco/shared-consts';
-import { getStageIndex } from './session';
+import { createSelector } from '@reduxjs/toolkit';
+import getQuery from '~/lib/network-query/query';
+import { SkipLogicAction } from '../protocol-consts';
+import { getNetwork } from './network';
+import { getProtocolStages } from './protocol';
+import { getStageIndex } from './shared';
 
 const formatQueryParameters = (params: Record<string, unknown>) => ({
   rules: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fresco",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",


### PR DESCRIPTION
### Bug fix: Stale data from form submission impacting skip logic

#### Issue: 
Interview navigation functions (`moveForward` and `moveBackward`) were using stale values of `nextValidStageIndex` and `previousValidStageIndex` due to closures. When these indexes were updated during form submission in the `beforeNext` handler, the navigation functions weren't receiving the updated values. This resulted in behavior where if form data impacted skip logic, the skip logic wasn't working correctly.

#### Solution:
- Implemented using `useRef` to store index values as refs
- Added `useEffect` hooks to update these refs whenever indexes change
- Modified `moveForward` and `moveBackward` to use current ref values for updating session progress and stage instead of closure-captured variables

#### Other changes:
This investigation also revealed a circular deps issue and duplicate selectors (two duplicate versions of `getStageIndex`). Fixed this by moving some selectors (`getActiveSession`, `getStageIndex`) to a `shared` file and importing from there.