### PR TITLE
Fix: Missing 11th toggle button group color

### DIFF
--- a/lib/ui/components/Fields/ToggleButtonGroup.js
+++ b/lib/ui/components/Fields/ToggleButtonGroup.js
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
-import ToggleButton from './ToggleButton';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import Icon from '../Icon';
-import { asOptionObject, getValue } from './utils/options';
 import MarkdownLabel from './MarkdownLabel';
+import ToggleButton from './ToggleButton';
+import { asOptionObject, getValue } from './utils/options';
 
 class ToggleButtonGroup extends PureComponent {
   get value() {
@@ -36,6 +36,8 @@ class ToggleButtonGroup extends PureComponent {
   renderOption = (option, index) => {
     const { value: optionValue, label: optionLabel } = asOptionObject(option);
 
+    const numColors = 10;
+    const colorIndex = (index % numColors) + 1;
     return (
       <ToggleButton
         className="form-field-togglebutton-group__option"
@@ -46,7 +48,7 @@ class ToggleButtonGroup extends PureComponent {
           onChange: this.handleClickOption,
         }}
         label={optionLabel}
-        color={`cat-color-seq-${index + 1}`}
+        color={`cat-color-seq-${colorIndex}`}
       />
     );
   };

--- a/lib/ui/components/Fields/ToggleButtonGroup.js
+++ b/lib/ui/components/Fields/ToggleButtonGroup.js
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
-import ToggleButton from './ToggleButton';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import Icon from '../Icon';
-import { asOptionObject, getValue } from './utils/options';
 import MarkdownLabel from './MarkdownLabel';
+import ToggleButton from './ToggleButton';
+import { asOptionObject, getValue } from './utils/options';
 
 class ToggleButtonGroup extends PureComponent {
   get value() {
@@ -46,7 +46,7 @@ class ToggleButtonGroup extends PureComponent {
           onChange: this.handleClickOption,
         }}
         label={optionLabel}
-        color={`cat-color-seq-${index + 1}`}
+        color={`cat-color-seq-${index}`}
       />
     );
   };

--- a/lib/ui/components/Fields/ToggleButtonGroup.js
+++ b/lib/ui/components/Fields/ToggleButtonGroup.js
@@ -1,10 +1,10 @@
-import cx from 'classnames';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
-import Icon from '../Icon';
-import MarkdownLabel from './MarkdownLabel';
+import cx from 'classnames';
 import ToggleButton from './ToggleButton';
+import Icon from '../Icon';
 import { asOptionObject, getValue } from './utils/options';
+import MarkdownLabel from './MarkdownLabel';
 
 class ToggleButtonGroup extends PureComponent {
   get value() {
@@ -36,8 +36,6 @@ class ToggleButtonGroup extends PureComponent {
   renderOption = (option, index) => {
     const { value: optionValue, label: optionLabel } = asOptionObject(option);
 
-    const numColors = 10;
-    const colorIndex = (index % numColors) + 1;
     return (
       <ToggleButton
         className="form-field-togglebutton-group__option"
@@ -48,7 +46,7 @@ class ToggleButtonGroup extends PureComponent {
           onChange: this.handleClickOption,
         }}
         label={optionLabel}
-        color={`cat-color-seq-${colorIndex}`}
+        color={`cat-color-seq-${index + 1}`}
       />
     );
   };

--- a/lib/ui/styles/components/form/fields/_toggle-button.scss
+++ b/lib/ui/styles/components/form/fields/_toggle-button.scss
@@ -109,7 +109,7 @@ $component-name: form-field-togglebutton;
 }
 
 @for $i from 1 through 20 {
-  $sequence-number: $i % 11;
+  $sequence-number: $i % 10 + 1;
   .form-field-togglebutton-cat-color-seq-#{$i} {
     .form-field-togglebutton__checkbox {
       &::before {

--- a/lib/ui/styles/components/form/fields/_toggle-button.scss
+++ b/lib/ui/styles/components/form/fields/_toggle-button.scss
@@ -109,7 +109,7 @@ $component-name: form-field-togglebutton;
 }
 
 @for $i from 1 through 20 {
-  $sequence-number: $i % 10 + 1;
+  $sequence-number: ($i - 1) % 10 + 1;
   .form-field-togglebutton-cat-color-seq-#{$i} {
     .form-field-togglebutton__checkbox {
       &::before {

--- a/lib/ui/styles/components/form/fields/_toggle-button.scss
+++ b/lib/ui/styles/components/form/fields/_toggle-button.scss
@@ -108,8 +108,8 @@ $component-name: form-field-togglebutton;
   }
 }
 
-@for $i from 1 through 20 {
-  $sequence-number: ($i - 1) % 10 + 1;
+@for $i from 0 through 20 {
+  $sequence-number: $i % 10 + 1;
   .form-field-togglebutton-cat-color-seq-#{$i} {
     .form-field-togglebutton__checkbox {
       &::before {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fresco",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",


### PR DESCRIPTION
This PR fixes a bug where the 11th toggle button group did not have a color class, which made it appear to be un-selectable.