### PR TITLE
Add vercel automation bypass secret to update snapshots workflow

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run Playwright update snapshots
         run: pnpm exec playwright test --update-snapshots
         env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           E2E_UPLOADTHING_TOKEN: ${{ secrets.E2E_UPLOADTHING_TOKEN }}
           BASE_URL: ${{ steps.extract-url.outputs.preview_url }}
       - name: Commit and push updated snapshots


### PR DESCRIPTION
We added deployment protection to preview deployments. Playwright workflows now require the `VERCEL_AUTOMATION_BYPASS_SECRET` to bypass deployment protection. 

Handled as a separate PR from the e2e tests as this workflow must be in main to run. 