### PR TITLE
fix: duplicate ego uuids

### DIFF
--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -8,7 +8,7 @@ import { cookies } from 'next/headers';
 import superjson from 'superjson';
 import trackEvent from '~/lib/analytics';
 import { safeRevalidateTag } from '~/lib/cache';
-import { initialNetwork } from '~/lib/interviewer/ducks/modules/session';
+import { createInitialNetwork } from '~/lib/interviewer/ducks/modules/session';
 import { formatExportableSessions } from '~/lib/network-exporters/formatters/formatExportableSessions';
 import archive from '~/lib/network-exporters/formatters/session/archive';
 import { generateOutputFiles } from '~/lib/network-exporters/formatters/session/generateOutputFiles';
@@ -211,7 +211,7 @@ export async function createInterview(data: CreateInterview) {
         id: true,
       },
       data: {
-        network: initialNetwork,
+        network: createInitialNetwork(),
         participant: participantStatement,
         protocol: {
           connect: {

--- a/lib/interviewer/ducks/modules/session.ts
+++ b/lib/interviewer/ducks/modules/session.ts
@@ -19,7 +19,7 @@ import {
 } from '@reduxjs/toolkit';
 import { invariant } from 'es-toolkit';
 import { find, get } from 'es-toolkit/compat';
-import { v4 as uuid, v4 } from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { z } from 'zod/v3';
 import { generateSecureAttributes } from '../../containers/Interfaces/Anonymisation/utils';
 import { getAdditionalAttributesSelector } from '../../selectors/prop';
@@ -118,14 +118,14 @@ const actionTypes = {
   updateEgo: 'NETWORK/UPDATE_EGO' as const,
 };
 
-export const initialNetwork: NcNetwork = {
+export const createInitialNetwork = (): NcNetwork => ({
   ego: {
-    [entityPrimaryKeyProperty]: v4(),
+    [entityPrimaryKeyProperty]: uuid(),
     [entityAttributesProperty]: {},
   },
   nodes: [],
   edges: [],
-};
+});
 
 const initialState = {} as SessionState;
 


### PR DESCRIPTION
- Fixes duplicate `NetworkCanvasEgoUUID` bug: ego `uuid` was being created once as a constant `initialNetwork`, and used in `createInterview`. This fix turns `initialNetwork` -> `createInitialNetwork` and makes `createInterview` call this function instead so that a new `uuid` is created each time an interview is created.
