### PR TITLE
Create GitHub Actions Docker build workflow

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -37,6 +37,10 @@ on:
       - 'postcss.config.js'
       - 'tsconfig.json'
       - '.github/workflows/docker-build-pr.yml'
+      - 'postinstall.js'
+      - 'migrate-and-start.sh'
+      - 'setup-database.js'
+      - 'initialize.js'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building Docker images for pull requests. The workflow is triggered on relevant file changes or when called by other workflows, and it outputs the built Docker image as an artifact for further use in the CI/CD pipeline.

**New Docker build workflow:**

* Added `.github/workflows/docker-build-pr.yml` to build Docker images on pull requests or via workflow calls, generating uniquely named image artifacts and supporting caching for faster builds.
* Configured the workflow to trigger only when files relevant to the Docker build change, optimizing CI resource usage.
* Outputs the built Docker image as an artifact with a unique name based on the workflow run, making it available for subsequent jobs or workflows.