### PR TITLE
Fix Docker build by adding prisma generate to builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,10 @@ ENV SKIP_ENV_VALIDATION=true
 ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-# Enable pnpm and build
-RUN corepack enable pnpm && pnpm run build
+# Enable pnpm, generate Prisma client, and build
+# Note: prisma generate must run here because the generated client (lib/db/generated/)
+# is gitignored and not copied from deps stage (only node_modules is copied)
+RUN corepack enable pnpm && pnpm exec prisma generate && pnpm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
The Prisma generated client (lib/db/generated/) is gitignored and only created during pnpm install via postinstall. In the multi-stage Docker build, only node_modules was copied from the deps stage to builder stage, but the generated client lives outside node_modules. This caused the build to fail when Next.js tried to import from the non-existent generated client.

Adding `prisma generate` before `pnpm run build` ensures the client is available in the builder stage.