### PR TITLE
fix: Use dynamic import in CLI scripts to ensure adapter env var is l…

### DIFF
--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -2,7 +2,16 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { prisma } from '~/lib/db';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '~/lib/db/generated/client';
+
+// CLI scripts must use the PG adapter directly because the Neon serverless
+// adapter doesn't work in CLI/Node.js context (only in serverless runtimes)
+const adapter = new PrismaPg({
+  // eslint-disable-next-line no-process-env
+  connectionString: process.env.DATABASE_URL,
+});
+const prisma = new PrismaClient({ adapter });
 
 /**
  * We set the initializedAt key here, because this script is run when the

--- a/scripts/setup-database.ts
+++ b/scripts/setup-database.ts
@@ -2,8 +2,17 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { prisma } from '~/lib/db';
 import { execSync, spawnSync } from 'child_process';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '~/lib/db/generated/client';
+
+// CLI scripts must use the PG adapter directly because the Neon serverless
+// adapter doesn't work in CLI/Node.js context (only in serverless runtimes)
+const adapter = new PrismaPg({
+  // eslint-disable-next-line no-process-env
+  connectionString: process.env.DATABASE_URL,
+});
+const prisma = new PrismaClient({ adapter });
 
 type TableRow = {
   table_name: string;


### PR DESCRIPTION
…oaded

ES module imports are hoisted and evaluated before any code runs. This caused dotenv.config() to not execute before ~/env was evaluated, making USE_NEON_POSTGRES_ADAPTER unavailable during adapter selection.

Using dynamic import ensures env vars are loaded before the prisma module is imported, allowing the correct adapter to be used.