### PR TITLE
Fix export failing with "Body exceeded 1 MB limit" for large batches

### DIFF
--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createId } from '@paralleldrive/cuid2';
+import { unlink } from 'node:fs/promises';
 import {
   Prisma,
   type Interview,
@@ -95,7 +96,11 @@ export const exportInterviews = async (
 ): Promise<ExportReturn> => {
   await requireApiAuth();
 
+  const tempFilePaths: string[] = [];
+  let exportStage = 'initialisation';
+
   try {
+    exportStage = 'fetching interviews from database';
     const interviewsSessions = await getInterviewsForExport(interviewIds);
 
     const protocolsMap = new Map<string, Protocol>();
@@ -107,13 +112,27 @@ export const exportInterviews = async (
       Object.fromEntries(protocolsMap);
     const formattedSessions = formatExportableSessions(interviewsSessions);
 
-    const result = await Promise.resolve(formattedSessions)
-      .then(insertEgoIntoSessionNetworks)
-      .then(groupByProtocolProperty)
-      .then(resequenceIds)
-      .then(generateOutputFiles(formattedProtocols, exportOptions))
-      .then(archive)
-      .then(uploadZipToUploadThing);
+    exportStage = 'generating export files';
+    const sessionsWithEgo = insertEgoIntoSessionNetworks(formattedSessions);
+    const groupedSessions = groupByProtocolProperty(sessionsWithEgo);
+    const resequencedSessions = resequenceIds(groupedSessions);
+    const exportResults = await generateOutputFiles(
+      formattedProtocols,
+      exportOptions,
+    )(resequencedSessions);
+
+    exportResults.forEach((result) => {
+      if (result.success) {
+        tempFilePaths.push(result.filePath);
+      }
+    });
+
+    exportStage = 'creating zip archive';
+    const archiveResult = await archive(exportResults);
+    tempFilePaths.push(archiveResult.path);
+
+    exportStage = 'uploading zip file';
+    const result = await uploadZipToUploadThing(archiveResult);
 
     void trackEvent({
       type: 'DataExported',
@@ -132,6 +151,7 @@ export const exportInterviews = async (
     // eslint-disable-next-line no-console
     console.error(error);
     const e = ensureError(error);
+
     void trackEvent({
       type: 'Error',
       name: e.name,
@@ -139,15 +159,64 @@ export const exportInterviews = async (
       stack: e.stack,
       metadata: {
         path: '~/actions/interviews.ts',
+        exportStage,
+        interviewCount: interviewIds.length,
+        exportOptions,
       },
     });
 
+    const userMessage = getExportErrorMessage(e, exportStage);
+
     return {
       status: 'error',
-      error: `Error during data export: ${e.message}`,
+      error: userMessage,
     };
+  } finally {
+    await cleanupTempFiles(tempFilePaths);
   }
 };
+
+function getExportErrorMessage(error: Error, stage: string): string {
+  const message = error.message.toLowerCase();
+
+  if (message.includes('heap') || message.includes('memory')) {
+    return `Export ran out of memory while ${stage}. Try exporting fewer interviews at a time.`;
+  }
+
+  if (message.includes('enospc') || message.includes('no space')) {
+    return `Export ran out of disk space while ${stage}. Please free up server storage and try again.`;
+  }
+
+  if (
+    message.includes('timeout') ||
+    message.includes('timedout') ||
+    message.includes('timed out') ||
+    message.includes('etimedout') ||
+    message.includes('econnreset')
+  ) {
+    return `Export timed out while ${stage}. Try exporting fewer interviews at a time.`;
+  }
+
+  if (
+    message.includes('econnrefused') ||
+    message.includes('database') ||
+    message.includes('prisma')
+  ) {
+    return `Database connection failed while ${stage}. Please try again later.`;
+  }
+
+  return `Export failed while ${stage}: ${error.message}`;
+}
+
+async function cleanupTempFiles(filePaths: string[]) {
+  await Promise.allSettled(
+    filePaths.map((filePath) =>
+      unlink(filePath).catch(() => {
+        // Ignore cleanup errors — files may already be deleted
+      }),
+    ),
+  );
+}
 
 export async function createInterview(data: CreateInterview) {
   const { participantIdentifier, protocolId } = data;

--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -1,7 +1,11 @@
 'use server';
 
 import { createId } from '@paralleldrive/cuid2';
-import { Prisma, type Interview, type Protocol } from '~/lib/db/generated/client';
+import {
+  Prisma,
+  type Interview,
+  type Protocol,
+} from '~/lib/db/generated/client';
 import { cookies } from 'next/headers';
 import trackEvent from '~/lib/analytics';
 import { safeRevalidateTag } from '~/lib/cache';
@@ -15,7 +19,6 @@ import { resequenceIds } from '~/lib/network-exporters/formatters/session/resequ
 import type {
   ExportOptions,
   ExportReturn,
-  FormattedSession,
 } from '~/lib/network-exporters/utils/types';
 import { getAppSetting } from '~/queries/appSettings';
 import { getInterviewsForExport } from '~/queries/interviews';
@@ -86,32 +89,24 @@ export const updateExportTime = async (interviewIds: Interview['id'][]) => {
   }
 };
 
-export const prepareExportData = async (interviewIds: Interview['id'][]) => {
-  await requireApiAuth();
-
-  const interviewsSessions = await getInterviewsForExport(interviewIds);
-
-  const protocolsMap = new Map<string, Protocol>();
-  interviewsSessions.forEach((session) => {
-    protocolsMap.set(session.protocol.hash, session.protocol);
-  });
-
-  const formattedProtocols: InstalledProtocols =
-    Object.fromEntries(protocolsMap);
-  const formattedSessions = formatExportableSessions(interviewsSessions);
-
-  return { formattedSessions, formattedProtocols };
-};
-
-export const exportSessions = async (
-  formattedSessions: FormattedSession[],
-  formattedProtocols: InstalledProtocols,
+export const exportInterviews = async (
   interviewIds: Interview['id'][],
   exportOptions: ExportOptions,
 ): Promise<ExportReturn> => {
   await requireApiAuth();
 
   try {
+    const interviewsSessions = await getInterviewsForExport(interviewIds);
+
+    const protocolsMap = new Map<string, Protocol>();
+    interviewsSessions.forEach((session) => {
+      protocolsMap.set(session.protocol.hash, session.protocol);
+    });
+
+    const formattedProtocols: InstalledProtocols =
+      Object.fromEntries(protocolsMap);
+    const formattedSessions = formatExportableSessions(interviewsSessions);
+
     const result = await Promise.resolve(formattedSessions)
       .then(insertEgoIntoSessionNetworks)
       .then(groupByProtocolProperty)

--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -97,10 +97,9 @@ export const exportInterviews = async (
   await requireApiAuth();
 
   const tempFilePaths: string[] = [];
-  let exportStage = 'initialisation';
+  let exportStage = 'fetching interviews from database';
 
   try {
-    exportStage = 'fetching interviews from database';
     const interviewsSessions = await getInterviewsForExport(interviewIds);
 
     const protocolsMap = new Map<string, Protocol>();

--- a/app/dashboard/_components/InterviewsTable/InterviewsTable.tsx
+++ b/app/dashboard/_components/InterviewsTable/InterviewsTable.tsx
@@ -38,6 +38,11 @@ export const InterviewsTable = ({
     [interviews],
   );
 
+  const completedInterviews = useMemo(
+    () => interviews.filter((interview) => interview.finishTime),
+    [interviews],
+  );
+
   const handleDelete = (data: typeof interviews) => {
     setSelectedInterviews(data);
     setShowDeleteModal(true);
@@ -50,6 +55,11 @@ export const InterviewsTable = ({
 
   const handleExportAll = () => {
     setSelectedInterviews(interviews);
+    setShowExportModal(true);
+  };
+
+  const handleExportCompleted = () => {
+    setSelectedInterviews(completedInterviews);
     setShowExportModal(true);
   };
 
@@ -94,6 +104,12 @@ export const InterviewsTable = ({
               <DropdownMenuContent>
                 <DropdownMenuItem onClick={handleExportAll}>
                   Export all interviews
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={completedInterviews.length === 0}
+                  onClick={handleExportCompleted}
+                >
+                  Export all completed interviews
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   disabled={unexportedInterviews.length === 0}

--- a/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
+++ b/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
@@ -2,11 +2,7 @@ import type { Interview } from '~/lib/db/generated/client';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { FileWarning, Loader2, XCircle } from 'lucide-react';
 import { useState } from 'react';
-import {
-  exportSessions,
-  prepareExportData,
-  updateExportTime,
-} from '~/actions/interviews';
+import { exportInterviews, updateExportTime } from '~/actions/interviews';
 import { deleteZipFromUploadThing } from '~/actions/uploadThing';
 import { Button } from '~/components/ui/Button';
 import { cardClasses } from '~/components/ui/card';
@@ -29,7 +25,7 @@ import ExportOptionsView from './ExportOptionsView';
 
 const ExportingStateAnimation = () => {
   return (
-    <div className="fixed inset-0 z-99 flex flex-col items-center justify-center gap-3 bg-background/80 text-primary">
+    <div className="bg-background/80 text-primary fixed inset-0 z-99 flex flex-col items-center justify-center gap-3">
       <div
         className={cn(
           cardClasses,
@@ -80,14 +76,7 @@ export const ExportInterviewsDialog = ({
     try {
       const interviewIds = interviewsToExport.map((interview) => interview.id);
 
-      // prepare data for export
-      const { formattedSessions, formattedProtocols } =
-        await prepareExportData(interviewIds);
-
-      // export the data
-      const { zipUrl, zipKey, status, error } = await exportSessions(
-        formattedSessions,
-        formattedProtocols,
+      const { zipUrl, zipKey, status, error } = await exportInterviews(
         interviewIds,
         exportOptions,
       );

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -8,7 +8,6 @@ type StaticTag =
   | 'getParticipants'
   | 'getInterviewById'
   | 'getProtocols'
-  | 'getInterviewsForExport'
   | 'getProtocolsByHash'
   | 'getExistingAssetIds'
   | 'interviewCount'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fresco",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",

--- a/queries/interviews.ts
+++ b/queries/interviews.ts
@@ -14,23 +14,20 @@ export const getInterviews = createCachedFunction(async () => {
 
 export type GetInterviewsReturnType = ReturnType<typeof getInterviews>;
 
-export const getInterviewsForExport = createCachedFunction(
-  async (interviewIds: string[]) => {
-    const interviews = await prisma.interview.findMany({
-      where: {
-        id: {
-          in: interviewIds,
-        },
+export const getInterviewsForExport = async (interviewIds: string[]) => {
+  const interviews = await prisma.interview.findMany({
+    where: {
+      id: {
+        in: interviewIds,
       },
-      include: {
-        protocol: true,
-        participant: true,
-      },
-    });
-    return interviews;
-  },
-  ['getInterviewsForExport', 'getInterviews'],
-);
+    },
+    include: {
+      protocol: true,
+      participant: true,
+    },
+  });
+  return interviews;
+};
 
 export const getInterviewById = (interviewId: string) =>
   createCachedFunction(


### PR DESCRIPTION
Merge prepareExportData and exportSessions into a single exportInterviews server action so interview data is fetched and processed entirely server-side. Previously, the full interview network data was sent from server to client (prepareExportData) and then back to the server (exportSessions), causing the request body to exceed Next.js's 1 MB server action limit with large exports. Now only interview IDs and export options are sent in the request body.