### PR TITLE
Add real-time progress feedback to interview data export

### DIFF
--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -1,24 +1,12 @@
 'use server';
 
 import { createId } from '@paralleldrive/cuid2';
-import { Effect, Queue } from 'effect';
 import { after } from 'next/server';
 import { safeRevalidateTag, safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { type Interview } from '~/lib/db/generated/client';
-import type { ExportEvent } from '~/lib/export/exportEvents';
-import { ExportLayer } from '~/lib/export/layers/ExportLayer';
-import { exportPipeline } from '~/lib/export/pipeline';
 import { createInitialNetwork } from '~/lib/interviewer/ducks/modules/session';
-import type {
-  ExportOptions,
-  ExportReturn,
-} from '~/lib/network-exporters/utils/types';
-import {
-  captureEvent,
-  captureException,
-  shutdownPostHog,
-} from '~/lib/posthog-server';
+import { captureException, shutdownPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import type { CreateInterview, DeleteInterviews } from '~/schemas/interviews';
 import { requireApiAuth } from '~/utils/auth';
@@ -80,47 +68,6 @@ export const updateExportTime = async (interviewIds: Interview['id'][]) => {
   } catch (error) {
     return { error: 'Failed to update interviews', interview: null };
   }
-};
-
-export const exportInterviews = async (
-  interviewIds: Interview['id'][],
-  exportOptions: ExportOptions,
-): Promise<ExportReturn> => {
-  await requireApiAuth();
-
-  const result = await Effect.gen(function* () {
-    const queue = yield* Queue.unbounded<ExportEvent>();
-    return yield* exportPipeline(interviewIds, exportOptions, queue);
-  }).pipe(
-    Effect.catchAll((error) =>
-      Effect.succeed({
-        status: 'error' as const,
-        error: error.userMessage,
-      } satisfies ExportReturn),
-    ),
-    Effect.provide(ExportLayer),
-    Effect.runPromise,
-  );
-
-  after(async () => {
-    if (result.status === 'error') {
-      await captureException(new Error(result.error ?? 'Unknown error'), {
-        interviewCount: interviewIds.length,
-        exportOptions,
-      });
-    } else {
-      await captureEvent('DataExported', {
-        status: result.status,
-        sessions: interviewIds.length,
-        exportOptions,
-        result,
-      });
-    }
-    await shutdownPostHog();
-  });
-
-  safeUpdateTag('getInterviews');
-  return result;
 };
 
 export async function createInterview(data: CreateInterview) {

--- a/actions/interviews.ts
+++ b/actions/interviews.ts
@@ -1,11 +1,12 @@
 'use server';
 
 import { createId } from '@paralleldrive/cuid2';
-import { Effect } from 'effect';
+import { Effect, Queue } from 'effect';
 import { after } from 'next/server';
 import { safeRevalidateTag, safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { type Interview } from '~/lib/db/generated/client';
+import type { ExportEvent } from '~/lib/export/exportEvents';
 import { ExportLayer } from '~/lib/export/layers/ExportLayer';
 import { exportPipeline } from '~/lib/export/pipeline';
 import { createInitialNetwork } from '~/lib/interviewer/ducks/modules/session';
@@ -87,7 +88,10 @@ export const exportInterviews = async (
 ): Promise<ExportReturn> => {
   await requireApiAuth();
 
-  const result = await exportPipeline(interviewIds, exportOptions).pipe(
+  const result = await Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<ExportEvent>();
+    return yield* exportPipeline(interviewIds, exportOptions, queue);
+  }).pipe(
     Effect.catchAll((error) =>
       Effect.succeed({
         status: 'error' as const,

--- a/actions/synthetic-interviews.ts
+++ b/actions/synthetic-interviews.ts
@@ -5,6 +5,19 @@ import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { requireApiAuth } from '~/utils/auth';
 
+export async function revalidateSyntheticData() {
+  await requireApiAuth();
+
+  safeUpdateTag([
+    'getInterviews',
+    'getParticipants',
+    'interviewCount',
+    'participantCount',
+    'summaryStatistics',
+    'activityFeed',
+  ]);
+}
+
 export async function deleteSyntheticData() {
   await requireApiAuth();
 

--- a/app/api/export-interviews/route.ts
+++ b/app/api/export-interviews/route.ts
@@ -21,7 +21,15 @@ export async function POST(request: Request) {
     });
   }
 
-  const body: unknown = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+    });
+  }
+
   const parsed = exportInterviewsSchema.safeParse(body);
 
   if (!parsed.success) {

--- a/app/api/export-interviews/route.ts
+++ b/app/api/export-interviews/route.ts
@@ -1,0 +1,90 @@
+import { Effect, Queue, Stream } from 'effect';
+import { addEvent } from '~/actions/activityFeed';
+import { safeRevalidateTag } from '~/lib/cache';
+import { type ExportEvent, formatSSE } from '~/lib/export/exportEvents';
+import { ExportLayer } from '~/lib/export/layers/ExportLayer';
+import { exportPipeline } from '~/lib/export/pipeline';
+import { captureEvent, captureException } from '~/lib/posthog-server';
+import { exportInterviewsSchema } from '~/schemas/export';
+import { requireApiAuth } from '~/utils/auth';
+
+export async function POST(request: Request) {
+  try {
+    await requireApiAuth();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+    });
+  }
+
+  const body: unknown = await request.json();
+  const parsed = exportInterviewsSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+      status: 400,
+    });
+  }
+
+  const { interviewIds, exportOptions } = parsed.data;
+
+  const program = Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<ExportEvent>();
+
+    yield* exportPipeline(interviewIds, exportOptions, queue).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          safeRevalidateTag(['getInterviews', 'activityFeed']);
+          void addEvent(
+            'Data Exported',
+            `Exported data for ${String(interviewIds.length)} interview(s)`,
+          );
+          void captureEvent('Data Exported', {
+            interviewCount: interviewIds.length,
+          });
+        }).pipe(
+          Effect.andThen(
+            Queue.offer(queue, {
+              type: 'complete',
+              zipUrl: result.zipUrl ?? '',
+              zipKey: result.zipKey ?? '',
+            }),
+          ),
+        ),
+      ),
+      Effect.tapError((error) =>
+        Effect.sync(() => {
+          void captureException(error);
+        }).pipe(
+          Effect.andThen(
+            Queue.offer(queue, {
+              type: 'error',
+              message: error.userMessage,
+            }),
+          ),
+        ),
+      ),
+      Effect.catchAll(() => Effect.void),
+      Effect.ensuring(Queue.shutdown(queue)),
+      Effect.provide(ExportLayer),
+      Effect.fork,
+    );
+
+    const encoder = new TextEncoder();
+    const sseStream = Stream.fromQueue(queue).pipe(
+      Stream.map((event) => encoder.encode(formatSSE(event))),
+    );
+
+    return Stream.toReadableStream(sseStream);
+  });
+
+  const readableStream = await Effect.runPromise(program);
+
+  return new Response(readableStream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}

--- a/app/api/export-interviews/route.ts
+++ b/app/api/export-interviews/route.ts
@@ -4,7 +4,11 @@ import { safeRevalidateTag } from '~/lib/cache';
 import { type ExportEvent, formatSSE } from '~/lib/export/exportEvents';
 import { ExportLayer } from '~/lib/export/layers/ExportLayer';
 import { exportPipeline } from '~/lib/export/pipeline';
-import { captureEvent, captureException } from '~/lib/posthog-server';
+import {
+  captureEvent,
+  captureException,
+  shutdownPostHog,
+} from '~/lib/posthog-server';
 import { exportInterviewsSchema } from '~/schemas/export';
 import { requireApiAuth } from '~/utils/auth';
 
@@ -41,7 +45,7 @@ export async function POST(request: Request) {
           );
           void captureEvent('Data Exported', {
             interviewCount: interviewIds.length,
-          });
+          }).then(() => shutdownPostHog());
         }).pipe(
           Effect.andThen(
             Queue.offer(queue, {
@@ -54,7 +58,7 @@ export async function POST(request: Request) {
       ),
       Effect.tapError((error) =>
         Effect.sync(() => {
-          void captureException(error);
+          void captureException(error).then(() => shutdownPostHog());
         }).pipe(
           Effect.andThen(
             Queue.offer(queue, {

--- a/app/api/export-interviews/route.ts
+++ b/app/api/export-interviews/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
       Effect.catchAll(() => Effect.void),
       Effect.ensuring(Queue.shutdown(queue)),
       Effect.provide(ExportLayer),
-      Effect.fork,
+      Effect.forkDaemon,
     );
 
     const encoder = new TextEncoder();

--- a/app/api/generate-test-interviews/route.ts
+++ b/app/api/generate-test-interviews/route.ts
@@ -14,7 +14,15 @@ export async function POST(request: Request) {
     });
   }
 
-  const body: unknown = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+    });
+  }
+
   const parsed = generateSyntheticInterviewsSchema.safeParse(body);
 
   if (!parsed.success) {

--- a/app/api/generate-test-interviews/route.ts
+++ b/app/api/generate-test-interviews/route.ts
@@ -1,6 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
 import { addEvent } from '~/actions/activityFeed';
-import { safeRevalidateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { generateNetwork } from '~/lib/synthetic-interviews/generateNetwork';
 import { generateSyntheticInterviewsSchema } from '~/schemas/synthetic-interviews';
@@ -125,15 +124,6 @@ export async function POST(request: Request) {
 
           send({ type: 'progress', current: i + 1, total: count });
         }
-
-        safeRevalidateTag([
-          'getInterviews',
-          'getParticipants',
-          'interviewCount',
-          'participantCount',
-          'summaryStatistics',
-          'activityFeed',
-        ]);
 
         void addEvent(
           'Synthetic Data Generated',

--- a/app/dashboard/_components/InterviewsTable/ActionsDropdown.tsx
+++ b/app/dashboard/_components/InterviewsTable/ActionsDropdown.tsx
@@ -16,19 +16,22 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu';
-import type { Interview } from '~/lib/db/generated/client';
+import type { GetInterviewsQuery } from '~/queries/interviews';
 
-export const ActionsDropdown = ({ row }: { row: Row<Interview> }) => {
+type InterviewRow = GetInterviewsQuery[number];
+
+export const ActionsDropdown = ({ row }: { row: Row<InterviewRow> }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
-  const [selectedInterviews, setSelectedInterviews] = useState<Interview[]>();
+  const [selectedInterviews, setSelectedInterviews] =
+    useState<InterviewRow[]>();
 
-  const handleDelete = (data: Interview) => {
+  const handleDelete = (data: InterviewRow) => {
     setSelectedInterviews([data]);
     setShowDeleteModal(true);
   };
 
-  const handleExport = (data: Interview) => {
+  const handleExport = (data: InterviewRow) => {
     setSelectedInterviews([data]);
     setShowExportModal(true);
   };

--- a/app/dashboard/_components/InterviewsTable/Columns.tsx
+++ b/app/dashboard/_components/InterviewsTable/Columns.tsx
@@ -158,8 +158,8 @@ export const InterviewColumns = (): ColumnDef<
     enableSorting: false,
     accessorFn: (row) => {
       const network = row.network;
-      const nodeCount = network?.nodes?.length ?? 0;
-      const edgeCount = network?.edges?.length ?? 0;
+      const nodeCount = network.nodes.reduce((sum, n) => sum + n.count, 0);
+      const edgeCount = network.edges.reduce((sum, e) => sum + e.count, 0);
       return nodeCount + edgeCount;
     },
     header: ({ column }) => {

--- a/app/dashboard/_components/InterviewsTable/Columns.tsx
+++ b/app/dashboard/_components/InterviewsTable/Columns.tsx
@@ -130,17 +130,16 @@ export const InterviewColumns = (): ColumnDef<
   {
     id: 'progress',
     accessorFn: (row) => {
-      const stages = row.protocol.stages;
-      return Array.isArray(stages)
-        ? (row.currentStep / stages.length) * 100
-        : 0;
+      const stageCount = row.protocol.stageCount;
+      return stageCount > 0 ? (row.currentStep / stageCount) * 100 : 0;
     },
     header: ({ column }) => {
       return <DataTableColumnHeader column={column} title="Progress" />;
     },
     cell: ({ row }) => {
-      const stages = row.original.protocol.stages;
-      const progress = (row.original.currentStep / stages.length) * 100;
+      const stageCount = row.original.protocol.stageCount;
+      const progress =
+        stageCount > 0 ? (row.original.currentStep / stageCount) * 100 : 0;
       return (
         <div className="flex items-center whitespace-nowrap">
           <ProgressBar
@@ -166,10 +165,7 @@ export const InterviewColumns = (): ColumnDef<
       return <DataTableColumnHeader column={column} title="Network" />;
     },
     cell: ({ row }) => {
-      const network = row.original.network;
-      const codebook = row.original.protocol.codebook;
-
-      return <NetworkSummary network={network} codebook={codebook} />;
+      return <NetworkSummary network={row.original.network} />;
     },
   },
   {

--- a/app/dashboard/_components/InterviewsTable/NetworkSummary.tsx
+++ b/app/dashboard/_components/InterviewsTable/NetworkSummary.tsx
@@ -1,5 +1,4 @@
-import { type Codebook } from '@codaco/protocol-validation';
-import Node from '~/components/Node';
+import Node, { type NodeColorSequence } from '~/components/Node';
 import type { GetInterviewsQuery } from '~/queries/interviews';
 import { cx } from '~/utils/cva';
 
@@ -109,42 +108,32 @@ function EdgeSummary({ color, count, typeName }: EdgeSummaryProps) {
 
 const NetworkSummary = ({
   network,
-  codebook,
 }: {
   network: GetInterviewsQuery[number]['network'];
-  codebook: Codebook | null;
 }) => {
-  if (!codebook) {
-    return <div className="text-xs">No interview data</div>;
-  }
-
-  const nodeSummaries = network.nodes.map(({ type: nodeType, count }) => {
-    const nodeInfo = codebook.node?.[nodeType];
-
-    return (
+  const nodeSummaries = network.nodes.map(
+    ({ type: nodeType, count, name, color }) => (
       <div className="flex flex-col items-center" key={nodeType}>
         <Node
           size="xxs"
-          color={nodeInfo?.color}
+          color={color as NodeColorSequence}
           label={count.toLocaleString()}
         />
-        <span className="pt-1 text-xs">{nodeInfo?.name ?? 'Unknown'}</span>
+        <span className="pt-1 text-xs">{name}</span>
       </div>
-    );
-  });
+    ),
+  );
 
   const edgeSummaries = network.edges
-    .map(({ type: edgeType, count }) => {
-      const edgeInfo = codebook.edge?.[edgeType];
-
-      if (!edgeInfo) return null;
+    .map(({ type: edgeType, count, name, color }) => {
+      if (!color) return null;
 
       return (
         <EdgeSummary
           key={edgeType}
-          color={edgeInfo.color as EdgeColorSequence}
+          color={color as EdgeColorSequence}
           count={count}
-          typeName={edgeInfo.name}
+          typeName={name}
         />
       );
     })

--- a/app/dashboard/_components/InterviewsTable/NetworkSummary.tsx
+++ b/app/dashboard/_components/InterviewsTable/NetworkSummary.tsx
@@ -1,6 +1,6 @@
 import { type Codebook } from '@codaco/protocol-validation';
-import type { NcNetwork } from '@codaco/shared-consts';
 import Node from '~/components/Node';
+import type { GetInterviewsQuery } from '~/queries/interviews';
 import { cx } from '~/utils/cva';
 
 // TODO: Move to shared-consts or protocol-validation
@@ -111,18 +111,14 @@ const NetworkSummary = ({
   network,
   codebook,
 }: {
-  network: NcNetwork | null;
+  network: GetInterviewsQuery[number]['network'];
   codebook: Codebook | null;
 }) => {
-  if (!network || !codebook) {
+  if (!codebook) {
     return <div className="text-xs">No interview data</div>;
   }
-  const nodeSummaries = Object.entries(
-    network.nodes?.reduce<Record<string, number>>((acc, node) => {
-      acc[node.type] = (acc[node.type] ?? 0) + 1;
-      return acc;
-    }, {}) ?? {},
-  ).map(([nodeType, count]) => {
+
+  const nodeSummaries = network.nodes.map(({ type: nodeType, count }) => {
     const nodeInfo = codebook.node?.[nodeType];
 
     return (
@@ -137,25 +133,22 @@ const NetworkSummary = ({
     );
   });
 
-  const edgeSummaries = Object.entries(
-    network.edges?.reduce<Record<string, number>>((acc, edge) => {
-      acc[edge.type] = (acc[edge.type] ?? 0) + 1;
-      return acc;
-    }, {}) ?? {},
-  ).map(([edgeType, count]) => {
-    const edgeInfo = codebook.edge?.[edgeType];
+  const edgeSummaries = network.edges
+    .map(({ type: edgeType, count }) => {
+      const edgeInfo = codebook.edge?.[edgeType];
 
-    if (!edgeInfo) return null;
+      if (!edgeInfo) return null;
 
-    return (
-      <EdgeSummary
-        key={edgeType}
-        color={edgeInfo.color as EdgeColorSequence}
-        count={count}
-        typeName={edgeInfo.name}
-      />
-    );
-  });
+      return (
+        <EdgeSummary
+          key={edgeType}
+          color={edgeInfo.color as EdgeColorSequence}
+          count={count}
+          typeName={edgeInfo.name}
+        />
+      );
+    })
+    .filter(Boolean);
 
   if (nodeSummaries.length === 0 && edgeSummaries.length === 0) {
     return <div className="text-xs">No nodes or edges</div>;

--- a/app/dashboard/interviews/_components/DeleteInterviewsDialog.tsx
+++ b/app/dashboard/interviews/_components/DeleteInterviewsDialog.tsx
@@ -3,13 +3,13 @@ import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
 import { deleteInterviews } from '~/actions/interviews';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/Alert';
 import { Button } from '~/components/ui/Button';
-import type { Interview } from '~/lib/db/generated/client';
+import type { GetInterviewsQuery } from '~/queries/interviews';
 import Dialog from '~/lib/dialogs/Dialog';
 
 type DeleteInterviewsDialog = {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
-  interviewsToDelete: Interview[];
+  interviewsToDelete: GetInterviewsQuery;
 };
 
 export const DeleteInterviewsDialog = ({

--- a/app/dashboard/interviews/_components/ExportCSVInterviewURLs.tsx
+++ b/app/dashboard/interviews/_components/ExportCSVInterviewURLs.tsx
@@ -26,7 +26,6 @@ function ExportCSVInterviewURLs({
       if (!protocol?.id) return;
 
       const csvData = interviews.map((interview) => ({
-        participant_id: interview.participantId,
         identifier: interview.participant.identifier,
         interview_url: `${window.location.origin}/interview/${interview.id}`,
       }));

--- a/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
+++ b/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
@@ -1,16 +1,9 @@
-import { Loader2 } from 'lucide-react';
-import { useState } from 'react';
-import { exportInterviews, updateExportTime } from '~/actions/interviews';
-import { deleteZipFromUploadThing } from '~/actions/uploadThing';
+import { useExportProgress } from '~/components/ExportProgressProvider';
 import { Button } from '~/components/ui/Button';
-import { useToast } from '~/components/ui/Toast';
-import { useDownload } from '~/hooks/useDownload';
 import useSafeLocalStorage from '~/hooks/useSafeLocalStorage';
-import posthog from 'posthog-js';
 import type { Interview } from '~/lib/db/generated/client';
 import Dialog from '~/lib/dialogs/Dialog';
 import { ExportOptionsSchema } from '~/lib/network-exporters/utils/types';
-import { ensureError } from '~/utils/ensureError';
 import ExportOptionsView from './ExportOptionsView';
 
 export const ExportInterviewsDialog = ({
@@ -22,9 +15,7 @@ export const ExportInterviewsDialog = ({
   handleCancel: () => void;
   interviewsToExport: Interview[];
 }) => {
-  const download = useDownload();
-  const { add } = useToast();
-  const [isExporting, setIsExporting] = useState(false);
+  const { startExport } = useExportProgress();
 
   const [exportOptions, setExportOptions] = useSafeLocalStorage(
     'exportOptions',
@@ -40,112 +31,31 @@ export const ExportInterviewsDialog = ({
     },
   );
 
-  const handleConfirm = async () => {
-    let exportFilename = null; // Used to track the filename of the temp file uploaded to UploadThing
-
-    // start export process
-    setIsExporting(true);
-    try {
-      const interviewIds = interviewsToExport.map((interview) => interview.id);
-
-      const { zipUrl, zipKey, status, error } = await exportInterviews(
-        interviewIds,
-        exportOptions,
-      );
-
-      if (status === 'error' || !zipUrl || !zipKey) {
-        throw new Error(error ?? 'An error occured during export.');
-      }
-
-      exportFilename = zipKey;
-
-      // update export time of interviews
-      await updateExportTime(interviewIds);
-
-      const responseAsBlob = await fetch(zipUrl).then((res) => {
-        if (!res.ok) {
-          throw new Error('HTTP error ' + res.status);
-        }
-        return res.blob();
-      });
-
-      // create a download link
-      const url = URL.createObjectURL(responseAsBlob);
-
-      // Download the zip file
-      download(url, 'Network Canvas Export.zip');
-      // clean up the URL object
-      URL.revokeObjectURL(url);
-
-      add({
-        title: 'Export complete!',
-        type: 'success',
-      });
-    } catch (error) {
-      const e = ensureError(error);
-
-      add({
-        title: 'Error',
-        description:
-          'Failed to export, please try again. The error was: ' + e.message,
-        type: 'destructive',
-      });
-
-      posthog.captureException(e);
-    } finally {
-      if (exportFilename) {
-        // Attempt to delete the zip file from UploadThing.
-        void deleteZipFromUploadThing(exportFilename).catch((error) => {
-          const e = ensureError(error);
-          posthog.captureException(e);
-
-          add({
-            timeout: Infinity,
-            type: 'destructive',
-            title: 'Could not delete temporary file',
-            description:
-              'We were unable to delete the temporary file containing your exported data, which is stored on your UploadThing account. Although extremely unlikely, it is possible that this file could be accessed by someone else. You can delete the file manually by visiting uploadthing.com and logging in with your GitHub account. Please contact us to report this issue.',
-          });
-        });
-      }
-
-      setIsExporting(false);
-      handleCancel(); // Close the dialog
-    }
+  const handleConfirm = () => {
+    const interviewIds = interviewsToExport.map((interview) => interview.id);
+    startExport(interviewIds, exportOptions);
+    handleCancel();
   };
 
   return (
-    <>
-      <Dialog
-        open={open}
-        closeDialog={() => {
-          if (!isExporting) {
-            handleCancel();
-          }
-        }}
-        title="Confirm File Export Options"
-        description="Before exporting, please confirm the export options that you wish to use. These options are identical to those found in Interviewer."
-        footer={
-          <>
-            <Button onClick={handleCancel} disabled={isExporting}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleConfirm}
-              color="primary"
-              disabled={isExporting}
-              icon={isExporting ? <Loader2 className="animate-spin" /> : null}
-            >
-              {isExporting ? 'Exporting...' : 'Start export process'}
-            </Button>
-          </>
-        }
-      >
-        <ExportOptionsView
-          exportOptions={exportOptions}
-          setExportOptions={setExportOptions}
-        />
-      </Dialog>
-    </>
+    <Dialog
+      open={open}
+      closeDialog={handleCancel}
+      title="Confirm File Export Options"
+      description="Before exporting, please confirm the export options that you wish to use. These options are identical to those found in Interviewer."
+      footer={
+        <>
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button onClick={handleConfirm} color="primary">
+            Start export process
+          </Button>
+        </>
+      }
+    >
+      <ExportOptionsView
+        exportOptions={exportOptions}
+        setExportOptions={setExportOptions}
+      />
+    </Dialog>
   );
 };

--- a/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
+++ b/app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
@@ -1,7 +1,7 @@
 import { useExportProgress } from '~/components/ExportProgressProvider';
 import { Button } from '~/components/ui/Button';
 import useSafeLocalStorage from '~/hooks/useSafeLocalStorage';
-import type { Interview } from '~/lib/db/generated/client';
+import type { GetInterviewsQuery } from '~/queries/interviews';
 import Dialog from '~/lib/dialogs/Dialog';
 import { ExportOptionsSchema } from '~/lib/network-exporters/utils/types';
 import ExportOptionsView from './ExportOptionsView';
@@ -13,7 +13,7 @@ export const ExportInterviewsDialog = ({
 }: {
   open: boolean;
   handleCancel: () => void;
-  interviewsToExport: Interview[];
+  interviewsToExport: GetInterviewsQuery;
 }) => {
   const { startExport } = useExportProgress();
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { type Metadata } from 'next';
 import { connection } from 'next/server';
 import { Suspense } from 'react';
 import NetlifyBadge from '~/components/NetlifyBadge';
+import { ExportProgressProvider } from '~/components/ExportProgressProvider';
 import { getAppSetting } from '~/queries/appSettings';
 import { NavigationBar } from './_components/NavigationBar';
 import UploadThingModal from './_components/UploadThingModal';
@@ -21,7 +22,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
       <Suspense fallback={null}>
         <UploadThingTokenGate />
       </Suspense>
-      {children}
+      <ExportProgressProvider>{children}</ExportProgressProvider>
       <NetlifyBadge />
     </div>
   );

--- a/app/dashboard/settings/_components/SyntheticInterviewDataSection.tsx
+++ b/app/dashboard/settings/_components/SyntheticInterviewDataSection.tsx
@@ -3,7 +3,10 @@
 import { useRouter } from 'next/navigation';
 import { use, useState } from 'react';
 import { SuperJSON } from 'superjson';
-import { deleteSyntheticData } from '~/actions/synthetic-interviews';
+import {
+  deleteSyntheticData,
+  revalidateSyntheticData,
+} from '~/actions/synthetic-interviews';
 import { useToast } from '~/components/ui/Toast';
 import SettingsCard from '~/components/settings/SettingsCard';
 import SettingsField from '~/components/settings/SettingsField';
@@ -102,6 +105,7 @@ export default function SyntheticInterviewDataSection({
       }
     } finally {
       setIsGenerating(false);
+      await revalidateSyntheticData();
       router.refresh();
     }
   };

--- a/components/ExportProgressProvider.tsx
+++ b/components/ExportProgressProvider.tsx
@@ -180,6 +180,7 @@ export function ExportProgressProvider({
                   description: 'Your download should start automatically.',
                   type: 'success',
                   timeout: 5000,
+                  onCancel: undefined,
                 });
 
                 void deleteZipFromUploadThing(data.zipKey).catch(

--- a/components/ExportProgressProvider.tsx
+++ b/components/ExportProgressProvider.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import posthog from 'posthog-js';
+import { createContext, useCallback, useContext, useRef } from 'react';
+import { updateExportTime } from '~/actions/interviews';
+import { deleteZipFromUploadThing } from '~/actions/uploadThing';
+import ProgressBar from '~/components/ui/ProgressBar';
+import { useToast } from '~/components/ui/Toast';
+import { useDownload } from '~/hooks/useDownload';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+import type { ExportOptions } from '~/lib/network-exporters/utils/types';
+import { ensureError } from '~/utils/ensureError';
+
+type ExportContextValue = {
+  startExport: (interviewIds: string[], exportOptions: ExportOptions) => void;
+};
+
+const ExportContext = createContext<ExportContextValue | null>(null);
+
+export function useExportProgress() {
+  const ctx = useContext(ExportContext);
+  if (!ctx) {
+    throw new Error(
+      'useExportProgress must be used within ExportProgressProvider',
+    );
+  }
+  return ctx;
+}
+
+function ExportProgressDescription({
+  stage,
+  message,
+  current,
+  total,
+}: {
+  stage: string;
+  message: string;
+  current?: number;
+  total?: number;
+}) {
+  const showProgress =
+    stage === 'generating' && total !== undefined && total > 0;
+  const percent =
+    showProgress && current !== undefined
+      ? Math.round((current / total) * 100)
+      : 0;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm opacity-60">
+        {showProgress
+          ? `${message} ${String(current)} / ${String(total)}`
+          : message}
+      </p>
+      {showProgress && (
+        <ProgressBar
+          orientation="horizontal"
+          percentProgress={percent}
+          nudge={false}
+          label="Export progress"
+          className="h-1.5"
+        />
+      )}
+    </div>
+  );
+}
+
+export function ExportProgressProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { add, update, close } = useToast();
+  const download = useDownload();
+  const abortControllers = useRef(new Map<string, AbortController>());
+
+  const cancelExport = useCallback(
+    (toastId: string) => {
+      const controller = abortControllers.current.get(toastId);
+      controller?.abort();
+      abortControllers.current.delete(toastId);
+      close(toastId);
+    },
+    [close],
+  );
+
+  const startExport = useCallback(
+    (interviewIds: string[], exportOptions: ExportOptions) => {
+      const controller = new AbortController();
+
+      const toastId = add({
+        title: 'Exporting interviews',
+        description: (
+          <ExportProgressDescription
+            stage="fetching"
+            message="Starting export..."
+          />
+        ),
+        type: 'loading',
+        timeout: 0,
+        onClose: () => cancelExport(toastId),
+        onCancel: () => cancelExport(toastId),
+      });
+
+      abortControllers.current.set(toastId, controller);
+
+      void (async () => {
+        try {
+          const response = await fetch('/api/export-interviews', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ interviewIds, exportOptions }),
+            signal: controller.signal,
+          });
+
+          if (!response.ok || !response.body) {
+            throw new Error(
+              `Export request failed with status ${String(response.status)}`,
+            );
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const events = buffer.split('\n\n');
+            buffer = events.pop() ?? '';
+
+            for (const event of events) {
+              const dataLine = event
+                .split('\n')
+                .find((line) => line.startsWith('data: '));
+              if (!dataLine) continue;
+
+              const data = JSON.parse(dataLine.slice(6)) as ExportEvent;
+
+              if (data.type === 'stage' || data.type === 'progress') {
+                update(toastId, {
+                  description: (
+                    <ExportProgressDescription
+                      stage={data.stage}
+                      message={
+                        data.type === 'stage'
+                          ? data.message
+                          : 'Generating files...'
+                      }
+                      current={'current' in data ? data.current : undefined}
+                      total={'total' in data ? data.total : undefined}
+                    />
+                  ),
+                });
+              } else if (data.type === 'complete') {
+                const responseAsBlob = await fetch(data.zipUrl).then((res) => {
+                  if (!res.ok)
+                    throw new Error('HTTP error ' + String(res.status));
+                  return res.blob();
+                });
+
+                const url = URL.createObjectURL(responseAsBlob);
+                download(url, 'Network Canvas Export.zip');
+                URL.revokeObjectURL(url);
+
+                await updateExportTime(interviewIds);
+
+                update(toastId, {
+                  title: 'Export complete!',
+                  description: 'Your download should start automatically.',
+                  type: 'success',
+                  timeout: 5000,
+                });
+
+                void deleteZipFromUploadThing(data.zipKey).catch(
+                  (error: unknown) => {
+                    const e = ensureError(error);
+                    posthog.captureException(e);
+
+                    add({
+                      timeout: Infinity,
+                      type: 'destructive',
+                      title: 'Could not delete temporary file',
+                      description:
+                        'We were unable to delete the temporary file containing your exported data, which is stored on your UploadThing account. Although extremely unlikely, it is possible that this file could be accessed by someone else. You can delete the file manually by visiting uploadthing.com and logging in with your GitHub account. Please contact us to report this issue.',
+                    });
+                  },
+                );
+              } else if (data.type === 'error') {
+                update(toastId, {
+                  title: 'Export failed',
+                  description: data.message,
+                  type: 'destructive',
+                  timeout: 0,
+                });
+
+                posthog.captureException(new Error(data.message));
+              }
+            }
+          }
+        } catch (error) {
+          if (controller.signal.aborted) return;
+
+          const e = ensureError(error);
+          update(toastId, {
+            title: 'Export failed',
+            description: e.message,
+            type: 'destructive',
+            timeout: 0,
+          });
+
+          posthog.captureException(e);
+        } finally {
+          abortControllers.current.delete(toastId);
+        }
+      })();
+    },
+    [add, update, download, cancelExport],
+  );
+
+  return <ExportContext value={{ startExport }}>{children}</ExportContext>;
+}

--- a/components/ExportProgressProvider.tsx
+++ b/components/ExportProgressProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Loader2 } from 'lucide-react';
 import posthog from 'posthog-js';
 import { createContext, useCallback, useContext, useRef } from 'react';
 import { updateExportTime } from '~/actions/interviews';
@@ -47,11 +48,14 @@ function ExportProgressDescription({
 
   return (
     <div className="space-y-2">
-      <p className="text-sm opacity-60">
-        {showProgress
-          ? `${message} ${String(current)} / ${String(total)}`
-          : message}
-      </p>
+      <div className="flex items-center gap-2 text-sm opacity-60">
+        <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+        <p>
+          {showProgress
+            ? `${message} ${String(current)} / ${String(total)}`
+            : message}
+        </p>
+      </div>
       {showProgress && (
         <ProgressBar
           orientation="horizontal"
@@ -85,6 +89,7 @@ export function ExportProgressProvider({
       const controller = new AbortController();
 
       const toastId = add({
+        icon: <Loader2 className="size-5 animate-spin" aria-hidden="true" />,
         title: 'Exporting interviews',
         description: (
           <ExportProgressDescription
@@ -92,7 +97,6 @@ export function ExportProgressProvider({
             message="Starting export..."
           />
         ),
-        type: 'loading',
         timeout: 0,
         onClose: () => abortExport(toastId),
         onCancel: () => {

--- a/components/ExportProgressProvider.tsx
+++ b/components/ExportProgressProvider.tsx
@@ -74,15 +74,11 @@ export function ExportProgressProvider({
   const download = useDownload();
   const abortControllers = useRef(new Map<string, AbortController>());
 
-  const cancelExport = useCallback(
-    (toastId: string) => {
-      const controller = abortControllers.current.get(toastId);
-      controller?.abort();
-      abortControllers.current.delete(toastId);
-      close(toastId);
-    },
-    [close],
-  );
+  const abortExport = useCallback((toastId: string) => {
+    const controller = abortControllers.current.get(toastId);
+    controller?.abort();
+    abortControllers.current.delete(toastId);
+  }, []);
 
   const startExport = useCallback(
     (interviewIds: string[], exportOptions: ExportOptions) => {
@@ -98,8 +94,11 @@ export function ExportProgressProvider({
         ),
         type: 'loading',
         timeout: 0,
-        onClose: () => cancelExport(toastId),
-        onCancel: () => cancelExport(toastId),
+        onClose: () => abortExport(toastId),
+        onCancel: () => {
+          abortExport(toastId);
+          close(toastId);
+        },
       });
 
       abortControllers.current.set(toastId, controller);
@@ -137,7 +136,12 @@ export function ExportProgressProvider({
                 .find((line) => line.startsWith('data: '));
               if (!dataLine) continue;
 
-              const data = JSON.parse(dataLine.slice(6)) as ExportEvent;
+              let data: ExportEvent;
+              try {
+                data = JSON.parse(dataLine.slice(6)) as ExportEvent;
+              } catch {
+                continue;
+              }
 
               if (data.type === 'stage' || data.type === 'progress') {
                 update(toastId, {
@@ -217,7 +221,7 @@ export function ExportProgressProvider({
         }
       })();
     },
-    [add, update, download, cancelExport],
+    [add, update, close, download, abortExport],
   );
 
   return <ExportContext value={{ startExport }}>{children}</ExportContext>;

--- a/components/ExportProgressProvider.tsx
+++ b/components/ExportProgressProvider.tsx
@@ -11,6 +11,7 @@ import { useDownload } from '~/hooks/useDownload';
 import type { ExportEvent } from '~/lib/export/exportEvents';
 import type { ExportOptions } from '~/lib/network-exporters/utils/types';
 import { ensureError } from '~/utils/ensureError';
+import Spinner from './Spinner';
 
 type ExportContextValue = {
   startExport: (interviewIds: string[], exportOptions: ExportOptions) => void;
@@ -89,7 +90,7 @@ export function ExportProgressProvider({
       const controller = new AbortController();
 
       const toastId = add({
-        icon: <Loader2 className="size-5 animate-spin" aria-hidden="true" />,
+        icon: <Spinner size="xs" aria-hidden="true" />,
         title: 'Exporting interviews',
         description: (
           <ExportProgressDescription
@@ -175,12 +176,13 @@ export function ExportProgressProvider({
 
                 await updateExportTime(interviewIds);
 
-                update(toastId, {
+                close(toastId);
+
+                add({
                   title: 'Export complete!',
                   description: 'Your download should start automatically.',
                   type: 'success',
                   timeout: 5000,
-                  onCancel: undefined,
                 });
 
                 void deleteZipFromUploadThing(data.zipKey).catch(

--- a/components/ui/Toast.stories.tsx
+++ b/components/ui/Toast.stories.tsx
@@ -69,10 +69,6 @@ function VariantsDemo() {
         title: 'Error',
         description: 'Something went wrong. Please try again.',
       },
-      loading: {
-        title: 'Loading',
-        description: 'Processing your request...',
-      },
     };
 
     add({
@@ -102,9 +98,6 @@ function VariantsDemo() {
         <Button variant="outline" onClick={() => createToast('destructive')}>
           Destructive
         </Button>
-        <Button variant="outline" onClick={() => createToast('loading')}>
-          Loading
-        </Button>
       </div>
     </div>
   );
@@ -123,7 +116,6 @@ function MultipleToastsDemo() {
     'info',
     'success',
     'destructive',
-    'loading',
   ];
 
   const createMultipleToasts = () => {
@@ -164,7 +156,6 @@ function LoadingDemo() {
     const id = add({
       title: 'Exporting interviews',
       description: 'Fetching interview data...',
-      type: 'loading',
       timeout: 0,
       onCancel: () => {
         // eslint-disable-next-line no-console

--- a/components/ui/Toast.stories.tsx
+++ b/components/ui/Toast.stories.tsx
@@ -69,6 +69,10 @@ function VariantsDemo() {
         title: 'Error',
         description: 'Something went wrong. Please try again.',
       },
+      loading: {
+        title: 'Loading',
+        description: 'Processing your request...',
+      },
     };
 
     add({
@@ -98,6 +102,9 @@ function VariantsDemo() {
         <Button variant="outline" onClick={() => createToast('destructive')}>
           Destructive
         </Button>
+        <Button variant="outline" onClick={() => createToast('loading')}>
+          Loading
+        </Button>
       </div>
     </div>
   );
@@ -116,6 +123,7 @@ function MultipleToastsDemo() {
     'info',
     'success',
     'destructive',
+    'loading',
   ];
 
   const createMultipleToasts = () => {
@@ -147,4 +155,56 @@ function MultipleToastsDemo() {
 
 export const MultipleToasts: Story = {
   render: () => <MultipleToastsDemo />,
+};
+
+function LoadingDemo() {
+  const { add, update } = useToast();
+
+  const simulateExport = () => {
+    const id = add({
+      title: 'Exporting interviews',
+      description: 'Fetching interview data...',
+      type: 'loading',
+      timeout: 0,
+      onCancel: () => {
+        // eslint-disable-next-line no-console
+        console.log('Export cancelled');
+      },
+    });
+
+    let current = 0;
+    const total = 10;
+    const interval = setInterval(() => {
+      current++;
+      if (current <= total) {
+        update(id, {
+          description: `Generating files... ${String(current)} / ${String(total)}`,
+        });
+      } else {
+        clearInterval(interval);
+        update(id, {
+          title: 'Export complete!',
+          description: 'Your download should start automatically.',
+          type: 'success',
+          timeout: 5000,
+        });
+      }
+    }, 500);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Heading level="h3" margin="none" className="text-lg">
+        Loading Toast (Export Progress)
+      </Heading>
+      <Paragraph margin="none" className="text-sm text-current/70">
+        Simulates an export with progress updates, then transitions to success.
+      </Paragraph>
+      <Button onClick={simulateExport}>Simulate Export</Button>
+    </div>
+  );
+}
+
+export const Loading: Story = {
+  render: () => <LoadingDemo />,
 };

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -5,7 +5,13 @@ import {
   type ToastObject,
   type UseToastManagerReturnValue,
 } from '@base-ui/react/toast';
-import { AlertCircle, Info, PartyPopper, type LucideIcon } from 'lucide-react';
+import {
+  AlertCircle,
+  Info,
+  Loader2,
+  PartyPopper,
+  type LucideIcon,
+} from 'lucide-react';
 import { cva, cx, type VariantProps } from '~/utils/cva';
 import { surfaceVariants } from '../layout/Surface';
 import Heading from '../typography/Heading';
@@ -20,6 +26,7 @@ export const toastVariants = cva({
       success: 'bg-success text-success-contrast border-success',
       destructive:
         'bg-destructive text-destructive-contrast border-destructive',
+      loading: 'bg-info text-info-contrast border-info',
     },
   },
   defaultVariants: {
@@ -36,6 +43,7 @@ export const variantIcons: Record<ToastVariant, LucideIcon | null> = {
   info: Info,
   success: PartyPopper,
   destructive: AlertCircle,
+  loading: Loader2,
 };
 
 type ToastData = {
@@ -46,10 +54,17 @@ type ToastData = {
   icon?: React.ReactNode;
   type?: ToastVariant;
   timeout?: number;
+  onCancel?: () => void;
+  onClose?: () => void;
+};
+
+type ToastCustomData = {
+  variant?: ToastVariant;
+  onCancel?: () => void;
 };
 
 type ToastItemProps = {
-  toast: ToastObject<{ variant?: ToastVariant }>;
+  toast: ToastObject<ToastCustomData>;
 };
 
 function ToastItem({ toast }: ToastItemProps) {
@@ -84,7 +99,10 @@ function ToastItem({ toast }: ToastItemProps) {
       <Toast.Content className="flex gap-3 overflow-hidden transition-opacity duration-250 data-behind:pointer-events-none data-behind:opacity-0 data-expanded:pointer-events-auto data-expanded:opacity-100">
         {IconComponent && (
           <IconComponent
-            className="mt-[0.1em] size-5 shrink-0"
+            className={cx(
+              'mt-[0.1em] size-5 shrink-0',
+              variant === 'loading' && 'animate-spin',
+            )}
             aria-hidden="true"
           />
         )}
@@ -93,6 +111,15 @@ function ToastItem({ toast }: ToastItemProps) {
           <Toast.Description
             render={<div className="font-body text-pretty not-last:mb-4" />}
           />
+          {toast.data?.onCancel && (
+            <button
+              type="button"
+              className="mt-2 rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+              onClick={toast.data.onCancel}
+            >
+              Cancel
+            </button>
+          )}
         </div>
         <Toast.Close
           render={<CloseButton size="sm" />}
@@ -117,12 +144,32 @@ type TypedUseToastManager = Omit<
 export function useToast(): TypedUseToastManager {
   const toastManager = Toast.useToastManager();
 
-  const toast = (data: ToastData) => {
-    toastManager.add(data);
+  const add = (toastData: ToastData) => {
+    const { onCancel, onClose, ...rest } = toastData;
+    return toastManager.add({
+      ...rest,
+      onClose,
+      data: { onCancel },
+    });
+  };
+
+  const update = (id: string, toastData: Partial<ToastData>) => {
+    const { onCancel, onClose, ...rest } = toastData;
+    toastManager.update(id, {
+      ...rest,
+      ...(onClose !== undefined && { onClose }),
+      ...(onCancel !== undefined && { data: { onCancel } }),
+    });
+  };
+
+  const toast = (toastData: ToastData) => {
+    add(toastData);
   };
 
   return {
     ...toastManager,
+    add,
+    update,
     toast,
   } as TypedUseToastManager;
 }

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -9,6 +9,7 @@ import { AlertCircle, Info, PartyPopper, type LucideIcon } from 'lucide-react';
 import { cva, cx, type VariantProps } from '~/utils/cva';
 import { surfaceVariants } from '../layout/Surface';
 import Heading from '../typography/Heading';
+import Button from './Button';
 import CloseButton from './CloseButton';
 
 export const toastVariants = cva({
@@ -53,6 +54,7 @@ type ToastData = {
 type ToastCustomData = {
   variant?: ToastVariant;
   onCancel?: () => void;
+  icon?: React.ReactNode;
 };
 
 type ToastItemProps = {
@@ -89,11 +91,15 @@ function ToastItem({ toast }: ToastItemProps) {
       )}
     >
       <Toast.Content className="flex gap-3 overflow-hidden transition-opacity duration-250 data-behind:pointer-events-none data-behind:opacity-0 data-expanded:pointer-events-auto data-expanded:opacity-100">
-        {IconComponent && (
-          <IconComponent
-            className="mt-[0.1em] size-5 shrink-0"
-            aria-hidden="true"
-          />
+        {toast.data?.icon ? (
+          <span className="mt-[0.1em] shrink-0">{toast.data.icon}</span>
+        ) : (
+          IconComponent && (
+            <IconComponent
+              className="mt-[0.1em] size-5 shrink-0"
+              aria-hidden="true"
+            />
+          )
         )}
         <div className="flex-1">
           <Toast.Title render={<Heading level="h4" />} />
@@ -101,13 +107,14 @@ function ToastItem({ toast }: ToastItemProps) {
             render={<div className="font-body text-pretty not-last:mb-4" />}
           />
           {toast.data?.onCancel && (
-            <button
+            <Button
               type="button"
-              className="mt-2 rounded bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+              size="sm"
               onClick={toast.data.onCancel}
+              className="mb-1"
             >
               Cancel
-            </button>
+            </Button>
           )}
         </div>
         <Toast.Close
@@ -134,11 +141,11 @@ export function useToast(): TypedUseToastManager {
   const toastManager = Toast.useToastManager();
 
   const add = (toastData: ToastData) => {
-    const { onCancel, onClose, ...rest } = toastData;
+    const { onCancel, onClose, icon, ...rest } = toastData;
     return toastManager.add({
       ...rest,
       onClose,
-      data: { onCancel },
+      data: { onCancel, icon },
     });
   };
 

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -5,13 +5,7 @@ import {
   type ToastObject,
   type UseToastManagerReturnValue,
 } from '@base-ui/react/toast';
-import {
-  AlertCircle,
-  Info,
-  Loader2,
-  PartyPopper,
-  type LucideIcon,
-} from 'lucide-react';
+import { AlertCircle, Info, PartyPopper, type LucideIcon } from 'lucide-react';
 import { cva, cx, type VariantProps } from '~/utils/cva';
 import { surfaceVariants } from '../layout/Surface';
 import Heading from '../typography/Heading';
@@ -26,7 +20,6 @@ export const toastVariants = cva({
       success: 'bg-success text-success-contrast border-success',
       destructive:
         'bg-destructive text-destructive-contrast border-destructive',
-      loading: 'bg-info text-info-contrast border-info',
     },
   },
   defaultVariants: {
@@ -43,7 +36,6 @@ export const variantIcons: Record<ToastVariant, LucideIcon | null> = {
   info: Info,
   success: PartyPopper,
   destructive: AlertCircle,
-  loading: Loader2,
 };
 
 type ToastData = {
@@ -99,10 +91,7 @@ function ToastItem({ toast }: ToastItemProps) {
       <Toast.Content className="flex gap-3 overflow-hidden transition-opacity duration-250 data-behind:pointer-events-none data-behind:opacity-0 data-expanded:pointer-events-auto data-expanded:opacity-100">
         {IconComponent && (
           <IconComponent
-            className={cx(
-              'mt-[0.1em] size-5 shrink-0',
-              variant === 'loading' && 'animate-spin',
-            )}
+            className="mt-[0.1em] size-5 shrink-0"
             aria-hidden="true"
           />
         )}

--- a/docs/superpowers/plans/2026-03-18-export-progress-feedback.md
+++ b/docs/superpowers/plans/2026-03-18-export-progress-feedback.md
@@ -1,0 +1,1404 @@
+# Export Progress Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add real-time progress feedback to the interview data export process using SSE and persistent toast notifications.
+
+**Architecture:** A new SSE route handler streams export progress events via Effect Queue/Stream. A React context provider manages active exports and drives persistent toast updates. The existing export pipeline is modified to push progress events between stages.
+
+**Tech Stack:** Effect (Queue, Stream, Ref), Next.js Route Handlers, @base-ui/react Toast, Zod, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-18-export-progress-feedback-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `lib/export/exportEvents.ts` | **NEW** — Export event type definitions and SSE helpers |
+| `lib/network-exporters/formatters/session/generateOutputFiles.ts` | **MODIFY** — Convert to Effect-returning function with per-file progress |
+| `lib/export/pipeline.ts` | **MODIFY** — Accept Queue, push stage/progress events |
+| `lib/export/__tests__/pipeline.test.ts` | **MODIFY** — Update tests for new pipeline signature |
+| `schemas/export.ts` | **NEW** — Zod schema for route handler request body |
+| `app/api/export-interviews/route.ts` | **NEW** — SSE route handler |
+| `components/ui/Toast.tsx` | **MODIFY** — Add `loading` variant, cancel button support |
+| `components/ui/Toast.stories.tsx` | **MODIFY** — Add loading variant story |
+| `components/ExportProgressProvider.tsx` | **NEW** — React context for managing active exports |
+| `app/dashboard/layout.tsx` | **MODIFY** — Wrap children in ExportProgressProvider |
+| `app/dashboard/interviews/_components/ExportInterviewsDialog.tsx` | **MODIFY** — Delegate to context, close immediately |
+| `actions/interviews.ts` | **MODIFY** — Remove `exportInterviews` server action |
+
+---
+
+### Task 1: Export Event Types
+
+Define the shared event types used by both the SSE route handler and client consumer.
+
+**Files:**
+- Create: `lib/export/exportEvents.ts`
+
+- [ ] **Step 1: Create the export event type definitions**
+
+```typescript
+// lib/export/exportEvents.ts
+import { z } from 'zod/mini';
+
+export const exportStages = [
+  'fetching',
+  'formatting',
+  'generating',
+  'archiving',
+  'uploading',
+] as const;
+
+export type ExportStage = (typeof exportStages)[number];
+
+export const stageMessages: Record<ExportStage, string> = {
+  fetching: 'Fetching interview data...',
+  formatting: 'Formatting sessions...',
+  generating: 'Generating files...',
+  archiving: 'Creating archive...',
+  uploading: 'Uploading...',
+};
+
+export type ExportStageEvent = {
+  type: 'stage';
+  stage: ExportStage;
+  message: string;
+  current?: number;
+  total?: number;
+};
+
+export type ExportProgressEvent = {
+  type: 'progress';
+  stage: 'generating';
+  current: number;
+  total: number;
+};
+
+export type ExportCompleteEvent = {
+  type: 'complete';
+  zipUrl: string;
+  zipKey: string;
+};
+
+export type ExportErrorEvent = {
+  type: 'error';
+  message: string;
+};
+
+export type ExportEvent =
+  | ExportStageEvent
+  | ExportProgressEvent
+  | ExportCompleteEvent
+  | ExportErrorEvent;
+
+export function formatSSE(event: ExportEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `pnpm typecheck`
+Expected: No errors in the new file
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write lib/export/exportEvents.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/export/exportEvents.ts
+git commit -m "feat: add export event type definitions for SSE progress"
+```
+
+---
+
+### Task 2: Convert `generateOutputFiles` to Effect
+
+Convert the file generation function from a curried async function using `Promise.all` to an Effect-returning function with per-file progress tracking.
+
+**Files:**
+- Modify: `lib/network-exporters/formatters/session/generateOutputFiles.ts`
+
+**Reference:**
+- Current implementation: curried async function at `generateOutputFiles.ts:13-56`
+- `exportFile` at `lib/network-exporters/formatters/session/exportFile.ts` returns `Promise<ExportResult>`
+- Pipeline callsite: `pipeline.ts:57-64` wraps in `Effect.tryPromise`
+
+- [ ] **Step 1: Write a test for the Effect-based generateOutputFiles**
+
+Create: `lib/network-exporters/formatters/session/__tests__/generateOutputFiles.test.ts`
+
+```typescript
+import { Effect, Queue, Ref } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { generateOutputFilesEffect } from '../generateOutputFiles';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+
+describe('generateOutputFilesEffect', () => {
+  it('is an Effect that reports progress events to a queue', async () => {
+    // This test verifies the function signature exists and returns an Effect.
+    // Full integration testing happens in the pipeline test.
+    // We verify the export is callable and the type is correct.
+    expect(generateOutputFilesEffect).toBeDefined();
+    expect(typeof generateOutputFilesEffect).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/network-exporters/formatters/session/__tests__/generateOutputFiles.test.ts`
+Expected: FAIL — `generateOutputFilesEffect` is not exported
+
+- [ ] **Step 3: Convert generateOutputFiles to an Effect-returning function**
+
+Modify `lib/network-exporters/formatters/session/generateOutputFiles.ts`. Keep the original export for backward compatibility during migration, add a new `generateOutputFilesEffect` export:
+
+```typescript
+import { Effect, Queue, Ref } from 'effect';
+import { invariant } from 'es-toolkit';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+import { ExportGenerationError, getUserMessage } from '~/lib/export/errors';
+import { type ExportedProtocol } from '~/lib/export/pipeline';
+import { getFilePrefix } from '../../utils/general';
+import type {
+  ExportFormat,
+  ExportOptions,
+  ExportResult,
+  SessionWithResequencedIDs,
+} from '../../utils/types';
+import exportFile from './exportFile';
+import { partitionByType } from './partitionByType';
+
+type ExportItem = {
+  prefix: string;
+  exportFormat: ExportFormat;
+  network: ReturnType<typeof partitionByType>[number];
+  codebook: Parameters<typeof exportFile>[0]['codebook'];
+  exportOptions: ExportOptions;
+};
+
+function buildExportItems(
+  protocols: Record<string, ExportedProtocol>,
+  exportOptions: ExportOptions,
+  unifiedSessions: Record<string, SessionWithResequencedIDs[]>,
+): ExportItem[] {
+  const exportFormats = [
+    ...(exportOptions.exportGraphML ? ['graphml'] : []),
+    ...(exportOptions.exportCSV ? ['attributeList', 'edgeList', 'ego'] : []),
+  ] as ExportFormat[];
+
+  const items: ExportItem[] = [];
+
+  Object.entries(unifiedSessions).forEach(([protocolKey, sessions]) => {
+    const codebook = protocols[protocolKey]?.codebook;
+    invariant(codebook, `No protocol found for key: ${protocolKey}`);
+
+    sessions.forEach((session) => {
+      const prefix = getFilePrefix(session);
+
+      exportFormats.forEach((format) => {
+        const partitionedNetworks = partitionByType(codebook, session, format);
+
+        partitionedNetworks.forEach((partitionedNetwork) => {
+          items.push({
+            prefix,
+            exportFormat: format,
+            network: partitionedNetwork,
+            codebook,
+            exportOptions,
+          });
+        });
+      });
+    });
+  });
+
+  return items;
+}
+
+export const generateOutputFilesEffect = (
+  protocols: Record<string, ExportedProtocol>,
+  exportOptions: ExportOptions,
+  unifiedSessions: Record<string, SessionWithResequencedIDs[]>,
+  progressQueue: Queue.Queue<ExportEvent>,
+) =>
+  Effect.gen(function* () {
+    const items = buildExportItems(protocols, exportOptions, unifiedSessions);
+    const total = items.length;
+    const completedRef = yield* Ref.make(0);
+
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'generating',
+      message: 'Generating files...',
+      current: 0,
+      total,
+    });
+
+    const results = yield* Effect.forEach(
+      items,
+      (item) =>
+        Effect.tryPromise({
+          try: () => exportFile(item),
+          catch: (error) =>
+            new ExportGenerationError({
+              cause: error,
+              userMessage: getUserMessage(error, 'generating export files'),
+            }),
+        }).pipe(
+          Effect.tap(() =>
+            Ref.updateAndGet(completedRef, (n) => n + 1).pipe(
+              Effect.tap((current) =>
+                Queue.offer(progressQueue, {
+                  type: 'progress',
+                  stage: 'generating',
+                  current,
+                  total,
+                }),
+              ),
+            ),
+          ),
+        ),
+      { concurrency: 'unbounded' },
+    );
+
+    return results;
+  });
+
+// Keep the original export for any other consumers during migration
+export const generateOutputFiles =
+  (protocols: Record<string, ExportedProtocol>, exportOptions: ExportOptions) =>
+  async (unifiedSessions: Record<string, SessionWithResequencedIDs[]>) => {
+    const items = buildExportItems(protocols, exportOptions, unifiedSessions);
+
+    const result = await Promise.all(items.map((item) => exportFile(item)));
+    return result;
+  };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/network-exporters/formatters/session/__tests__/generateOutputFiles.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 6: Run formatter**
+
+Run: `pnpm prettier --write lib/network-exporters/formatters/session/generateOutputFiles.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/network-exporters/formatters/session/generateOutputFiles.ts lib/network-exporters/formatters/session/__tests__/generateOutputFiles.test.ts
+git commit -m "feat: add Effect-based generateOutputFiles with per-file progress"
+```
+
+---
+
+### Task 3: Modify Export Pipeline to Accept Queue
+
+Update the export pipeline to accept an `Effect.Queue` and push stage events between steps. Use `generateOutputFilesEffect` instead of wrapping in `Effect.tryPromise`.
+
+**Files:**
+- Modify: `lib/export/pipeline.ts`
+- Modify: `lib/export/__tests__/pipeline.test.ts`
+
+**Reference:**
+- Current pipeline: `pipeline.ts:38-112`
+- Current test: `pipeline.test.ts:1-52`
+- Event types: `lib/export/exportEvents.ts`
+
+- [ ] **Step 1: Update the pipeline test**
+
+Modify `lib/export/__tests__/pipeline.test.ts` to provide a Queue and verify stage events are emitted:
+
+```typescript
+import { Effect, Layer, Queue } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { DatabaseError } from '~/lib/export/errors';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+import { NodeFileSystem } from '~/lib/export/layers/NodeFileSystem';
+import { exportPipeline } from '~/lib/export/pipeline';
+import { FileStorage } from '~/lib/export/services/FileStorage';
+import { InterviewRepository } from '~/lib/export/services/InterviewRepository';
+
+const defaultExportOptions = {
+  exportGraphML: true,
+  exportCSV: false,
+  globalOptions: {
+    useScreenLayoutCoordinates: true,
+    screenLayoutHeight: 1080,
+    screenLayoutWidth: 1920,
+  },
+};
+
+describe('exportPipeline', () => {
+  it('returns error when database fetch fails', async () => {
+    const MockRepo = Layer.succeed(InterviewRepository, {
+      getForExport: () =>
+        Effect.fail(
+          new DatabaseError({
+            cause: new Error('connection refused'),
+            userMessage: 'Database connection failed.',
+          }),
+        ),
+    });
+
+    const MockStorage = Layer.succeed(FileStorage, {
+      upload: () => Effect.succeed({ url: 'http://test/file.zip', key: 'k' }),
+      delete: () => Effect.void,
+    });
+
+    const testLayer = Layer.mergeAll(MockRepo, NodeFileSystem, MockStorage);
+
+    const result = await Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<ExportEvent>();
+      return yield* exportPipeline(
+        ['test-id'],
+        defaultExportOptions,
+        queue,
+      ).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            status: 'error' as const,
+            error: error.userMessage,
+          }),
+        ),
+      );
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('Database connection failed.');
+  });
+
+  it('emits stage events to the queue', async () => {
+    const MockRepo = Layer.succeed(InterviewRepository, {
+      getForExport: () =>
+        Effect.fail(
+          new DatabaseError({
+            cause: new Error('test'),
+            userMessage: 'Test error.',
+          }),
+        ),
+    });
+
+    const MockStorage = Layer.succeed(FileStorage, {
+      upload: () => Effect.succeed({ url: 'http://test/file.zip', key: 'k' }),
+      delete: () => Effect.void,
+    });
+
+    const testLayer = Layer.mergeAll(MockRepo, NodeFileSystem, MockStorage);
+
+    const events = await Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<ExportEvent>();
+
+      yield* exportPipeline(['test-id'], defaultExportOptions, queue).pipe(
+        Effect.catchAll(() => Effect.void),
+      );
+
+      return yield* Queue.takeAll(queue);
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
+
+    // Should have at least the 'fetching' stage event before the error
+    const stageEvents = [...events].filter((e) => e.type === 'stage');
+    expect(stageEvents.length).toBeGreaterThanOrEqual(1);
+    expect(stageEvents[0]?.stage).toBe('fetching');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/export/__tests__/pipeline.test.ts`
+Expected: FAIL — `exportPipeline` doesn't accept a queue argument
+
+- [ ] **Step 3: Update the pipeline to accept a Queue**
+
+Modify `lib/export/pipeline.ts`:
+
+```typescript
+import { basename } from 'node:path';
+import { Effect, Queue } from 'effect';
+import { generateOutputFilesEffect } from '~/lib/network-exporters/formatters/session/generateOutputFiles';
+import { formatExportableSessions } from '~/lib/network-exporters/formatters/formatExportableSessions';
+import groupByProtocolProperty from '~/lib/network-exporters/formatters/session/groupByProtocolProperty';
+import { insertEgoIntoSessionNetworks } from '~/lib/network-exporters/formatters/session/insertEgoIntoSessionNetworks';
+import { resequenceIds } from '~/lib/network-exporters/formatters/session/resequenceIds';
+import archive from '~/lib/network-exporters/formatters/session/archive';
+import type { ExportOptions, ExportReturn } from '~/lib/network-exporters/utils/types';
+import {
+  ArchiveError,
+  FileStorageError,
+  getUserMessage,
+} from '~/lib/export/errors';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+import { stageMessages } from '~/lib/export/exportEvents';
+import { FileStorage } from '~/lib/export/services/FileStorage';
+import { FileSystem } from '~/lib/export/services/FileSystem';
+import {
+  InterviewRepository,
+  type InterviewExportData,
+} from '~/lib/export/services/InterviewRepository';
+
+export type ExportedProtocol = InterviewExportData['protocol'];
+
+function buildProtocolsMap(
+  sessions: InterviewExportData[],
+): Record<string, ExportedProtocol> {
+  const protocolsMap = new Map<string, ExportedProtocol>();
+  sessions.forEach((session) => {
+    protocolsMap.set(session.protocol.hash, session.protocol);
+  });
+  return Object.fromEntries(protocolsMap);
+}
+
+const emitStage = (
+  queue: Queue.Queue<ExportEvent>,
+  stage: ExportEvent & { type: 'stage' },
+) => Queue.offer(queue, stage);
+
+export const exportPipeline = (
+  interviewIds: string[],
+  exportOptions: ExportOptions,
+  progressQueue: Queue.Queue<ExportEvent>,
+) =>
+  Effect.gen(function* () {
+    const repo = yield* InterviewRepository;
+    const fs = yield* FileSystem;
+    const fileStorage = yield* FileStorage;
+
+    // Stage: fetching
+    yield* emitStage(progressQueue, {
+      type: 'stage',
+      stage: 'fetching',
+      message: stageMessages.fetching,
+    });
+
+    const sessions = yield* repo
+      .getForExport(interviewIds)
+      .pipe(Effect.withSpan('export.fetch'));
+
+    // Stage: formatting
+    yield* emitStage(progressQueue, {
+      type: 'stage',
+      stage: 'formatting',
+      message: stageMessages.formatting,
+    });
+
+    const protocols = buildProtocolsMap(sessions);
+    const formatted = formatExportableSessions(sessions);
+    const withEgo = insertEgoIntoSessionNetworks(formatted);
+    const grouped = groupByProtocolProperty(withEgo);
+    const resequenced = resequenceIds(grouped);
+
+    // Stage: generating (emitted inside generateOutputFilesEffect)
+    const exportResults = yield* generateOutputFilesEffect(
+      protocols,
+      exportOptions,
+      resequenced,
+      progressQueue,
+    ).pipe(Effect.withSpan('export.generateFiles'));
+
+    const tempFilePaths = exportResults
+      .filter((r): r is Extract<typeof r, { success: true }> => r.success)
+      .map((r) => r.filePath);
+
+    // Stage: archiving
+    yield* emitStage(progressQueue, {
+      type: 'stage',
+      stage: 'archiving',
+      message: stageMessages.archiving,
+    });
+
+    const archiveResult = yield* Effect.tryPromise({
+      try: () => archive(exportResults),
+      catch: (error) =>
+        new ArchiveError({
+          cause: error,
+          userMessage: getUserMessage(error, 'creating zip archive'),
+        }),
+    }).pipe(Effect.withSpan('export.archive'));
+
+    tempFilePaths.push(archiveResult.path);
+
+    const fileName = basename(archiveResult.path);
+    if (!/^networkCanvasExport-\d+\.zip$/.test(fileName)) {
+      return yield* Effect.fail(
+        new FileStorageError({
+          cause: new Error(`Invalid archive filename: ${fileName}`),
+          userMessage: 'Export failed due to an internal error.',
+        }),
+      );
+    }
+
+    // Stage: uploading
+    yield* emitStage(progressQueue, {
+      type: 'stage',
+      stage: 'uploading',
+      message: stageMessages.uploading,
+    });
+
+    const archiveBuffer = yield* fs.readFile(archiveResult.path);
+    const { url, key } = yield* fileStorage
+      .upload(archiveBuffer, fileName)
+      .pipe(Effect.withSpan('export.upload'));
+
+    yield* Effect.forEach(
+      tempFilePaths,
+      (path) => fs.deleteFile(path).pipe(Effect.catchAll(() => Effect.void)),
+      { discard: true },
+    );
+
+    return {
+      zipUrl: url,
+      zipKey: key,
+      status: archiveResult.rejected.length
+        ? ('partial' as const)
+        : ('success' as const),
+      error: archiveResult.rejected.length ? 'Some exports failed' : null,
+      successfulExports: archiveResult.completed,
+      failedExports: archiveResult.rejected,
+    } satisfies ExportReturn;
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test lib/export/__tests__/pipeline.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 6: Run formatter**
+
+Run: `pnpm prettier --write lib/export/pipeline.ts lib/export/__tests__/pipeline.test.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/export/pipeline.ts lib/export/__tests__/pipeline.test.ts
+git commit -m "feat: add progress event queue to export pipeline"
+```
+
+---
+
+### Task 4: Create Export Request Schema
+
+**Files:**
+- Create: `schemas/export.ts`
+
+**Reference:**
+- `ExportOptionsSchema` at `lib/network-exporters/utils/types.ts:56-64`
+- Synthetic interviews schema pattern at `schemas/synthetic-interviews.ts`
+
+- [ ] **Step 1: Create the schema**
+
+```typescript
+// schemas/export.ts
+import { z } from 'zod/mini';
+import { ExportOptionsSchema } from '~/lib/network-exporters/utils/types';
+
+export const exportInterviewsSchema = z.object({
+  interviewIds: z.array(z.string()).check(z.minLength(1)),
+  exportOptions: ExportOptionsSchema,
+});
+
+export type ExportInterviewsInput = z.infer<typeof exportInterviewsSchema>;
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write schemas/export.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add schemas/export.ts
+git commit -m "feat: add Zod schema for export interviews request"
+```
+
+---
+
+### Task 5: Create SSE Route Handler
+
+**Files:**
+- Create: `app/api/export-interviews/route.ts`
+
+**Reference:**
+- Synthetic interviews route handler pattern: `app/api/generate-test-interviews/route.ts`
+- Export pipeline: `lib/export/pipeline.ts`
+- ExportLayer: `lib/export/layers/ExportLayer.ts`
+- PostHog server tracking: `lib/posthog-server.ts` (functions: `captureEvent`, `captureException`, `shutdownPostHog`)
+- Cache invalidation: use `safeRevalidateTag` (route handler context)
+- `addEvent` from `actions/activityFeed.ts` for activity feed
+
+- [ ] **Step 1: Create the route handler**
+
+```typescript
+// app/api/export-interviews/route.ts
+import { Effect, Queue, Stream } from 'effect';
+import { addEvent } from '~/actions/activityFeed';
+import { safeRevalidateTag } from '~/lib/cache';
+import { ExportLayer } from '~/lib/export/layers/ExportLayer';
+import { exportPipeline } from '~/lib/export/pipeline';
+import { type ExportEvent, formatSSE } from '~/lib/export/exportEvents';
+import {
+  captureEvent,
+  captureException,
+  shutdownPostHog,
+} from '~/lib/posthog-server';
+import { exportInterviewsSchema } from '~/schemas/export';
+import { requireApiAuth } from '~/utils/auth';
+
+export async function POST(request: Request) {
+  try {
+    await requireApiAuth();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+    });
+  }
+
+  const body: unknown = await request.json();
+  const parsed = exportInterviewsSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+      status: 400,
+    });
+  }
+
+  const { interviewIds, exportOptions } = parsed.data;
+  const encoder = new TextEncoder();
+
+  const program = Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<ExportEvent>();
+
+    // Run the pipeline in a forked fiber that pushes events to the queue.
+    // The fiber is forked (not joined) because the SSE stream consumes
+    // from the queue concurrently. When the pipeline completes or errors,
+    // it shuts down the queue, which ends the stream.
+    yield* exportPipeline(
+      interviewIds,
+      exportOptions,
+      queue,
+    ).pipe(
+      Effect.tap((result) =>
+        Queue.offer(queue, {
+          type: 'complete',
+          zipUrl: result.zipUrl ?? '',
+          zipKey: result.zipKey ?? '',
+        }),
+      ),
+      Effect.tapError((error) =>
+        Queue.offer(queue, {
+          type: 'error',
+          message: error.userMessage,
+        }),
+      ),
+      Effect.ensuring(Queue.shutdown(queue)),
+      Effect.provide(ExportLayer),
+      Effect.fork,
+    );
+
+    // Convert queue to SSE stream
+    const sseStream = Stream.fromQueue(queue).pipe(
+      Stream.map((event) => encoder.encode(formatSSE(event))),
+    );
+
+    return Stream.toReadableStream(sseStream);
+  });
+
+  const readableStream = await Effect.runPromise(program);
+
+  // Note: cache invalidation and analytics happen AFTER export completes.
+  // The client calls `updateExportTime` (server action) after receiving the
+  // 'complete' SSE event, which handles `safeUpdateTag('getInterviews')`.
+  // Server-side PostHog tracking is handled inside the pipeline's success
+  // path in the route handler. The implementer should add PostHog capture
+  // inside the pipeline's Effect.tap (after the complete event is queued)
+  // or as a fire-and-forget after the stream ends. Example:
+  //
+  // Effect.tap((result) =>
+  //   Effect.sync(() => {
+  //     void captureEvent('DataExported', { ... }).then(() => shutdownPostHog());
+  //     safeRevalidateTag(['getInterviews', 'activityFeed']);
+  //     void addEvent('Data Exported', `Exported data for ${interviewIds.length} interview(s)`);
+  //   })
+  // )
+
+  return new Response(readableStream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}
+```
+
+Note: The implementer should verify the exact Effect API for `Stream.toReadableStream` — it may need `Stream.toReadableStreamRuntime` or `Stream.toReadableStreamEffect` depending on whether the stream has unresolved service requirements. If the `ExportLayer` is provided before forking, the stream should be requirement-free. Test this at runtime and adjust if needed.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write app/api/export-interviews/route.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/export-interviews/route.ts
+git commit -m "feat: add SSE route handler for export progress streaming"
+```
+
+---
+
+### Task 6: Add `loading` Variant to Toast
+
+Add the `loading` variant with spinner icon and cancel button support to the existing toast system.
+
+**Files:**
+- Modify: `components/ui/Toast.tsx:14-106`
+- Modify: `components/ui/Toast.stories.tsx`
+
+**Reference:**
+- `toastVariants` CVA config: `Toast.tsx:14-28`
+- `variantIcons` map: `Toast.tsx:34-39`
+- `ToastData` type: `Toast.tsx:41-49`
+- `ToastItem` component: `Toast.tsx:55-106`
+- Lucide icons already imported: `AlertCircle`, `Info`, `PartyPopper`
+- `Loader2` from lucide-react is used elsewhere for spinners (e.g. `ExportInterviewsDialog.tsx:1`)
+
+- [ ] **Step 1: Add the loading variant and cancel support**
+
+In `components/ui/Toast.tsx`:
+
+1. Add `Loader2` to the lucide-react import (line 8)
+2. Add `loading` variant to `toastVariants` (after line 24, inside `variants.variant`):
+   ```
+   loading: 'bg-info text-info-contrast border-info',
+   ```
+3. Update `variantIcons` to include loading (line 34-39). Since `Loader2` is not a static icon (needs animation), create a small wrapper component:
+   ```typescript
+   function SpinnerIcon({ className, ...props }: React.ComponentProps<typeof Loader2>) {
+     return <Loader2 className={cx('animate-spin', className)} {...props} />;
+   }
+   ```
+   Then update variantIcons. Note: `variantIcons` currently maps to `LucideIcon | null`. Since our spinner wrapper matches the `LucideIcon` signature (it's a forwardRef component), it should be compatible. If TypeScript complains, the implementer should adjust the type to `React.ComponentType<{ className?: string }> | null` or similar.
+4. Add `onCancel` to `ToastData` type (line 41-49):
+   ```typescript
+   onCancel?: () => void;
+   ```
+5. In `ToastItem` (line 55-106), render a cancel button when the toast data has `onCancel`. Access toast data via `toast.data`. Add after the `Toast.Description` element (around line 95):
+   ```tsx
+   {toast.data?.onCancel && (
+     <button
+       onClick={toast.data.onCancel}
+       className="mt-2 rounded-md bg-white/10 px-3 py-1 text-xs hover:bg-white/20"
+       type="button"
+     >
+       Cancel
+     </button>
+   )}
+   ```
+6. Update `TypedUseToastManager` type to pass `onCancel` through correctly — the `add` and `update` methods need the `data` field to flow through to `ToastObject`.
+
+The exact implementation details for threading `onCancel` through the base-ui toast data layer will require checking how `toast.data` is typed. The `add()` method accepts a `data` property that gets attached to the `ToastObject`. The implementer should verify this works with the `@base-ui/react` toast API.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Add a storybook story for the loading variant**
+
+Add to `components/ui/Toast.stories.tsx`:
+
+```typescript
+function LoadingDemo() {
+  const { add, update, close } = useToast();
+
+  const simulateExport = () => {
+    const id = add({
+      title: 'Exporting interviews',
+      description: 'Fetching interview data...',
+      type: 'loading',
+      timeout: 0,
+    });
+
+    let current = 0;
+    const total = 10;
+    const interval = setInterval(() => {
+      current++;
+      if (current <= total) {
+        update(id, {
+          description: `Generating files... ${current} / ${total}`,
+        });
+      } else {
+        clearInterval(interval);
+        update(id, {
+          title: 'Export complete!',
+          description: 'Your download should start automatically.',
+          type: 'success',
+          timeout: 5000,
+        });
+      }
+    }, 500);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Heading level="h3" margin="none" className="text-lg">
+        Loading Toast (Export Progress)
+      </Heading>
+      <Paragraph margin="none" className="text-sm text-current/70">
+        Simulates an export with progress updates, then transitions to success.
+      </Paragraph>
+      <Button onClick={simulateExport}>Simulate Export</Button>
+    </div>
+  );
+}
+
+export const Loading: Story = {
+  render: () => <LoadingDemo />,
+};
+```
+
+- [ ] **Step 4: Run formatter**
+
+Run: `pnpm prettier --write components/ui/Toast.tsx components/ui/Toast.stories.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/ui/Toast.tsx components/ui/Toast.stories.tsx
+git commit -m "feat: add loading variant with spinner and cancel support to toast"
+```
+
+---
+
+### Task 7: Create ExportProgressProvider
+
+The React context provider that manages active exports, SSE connections, and toast lifecycle.
+
+**Files:**
+- Create: `components/ExportProgressProvider.tsx`
+
+**Reference:**
+- SSE consumption pattern: `app/dashboard/settings/_components/SyntheticInterviewDataSection.tsx:46-106`
+- Toast API: `useToast()` returns `{ add, update, close, toast }`
+- `useDownload` hook: `hooks/useDownload.ts`
+- `updateExportTime` server action: `actions/interviews.ts:56-82`
+- `deleteZipFromUploadThing` server action: `actions/uploadThing.ts`
+- Export event types: `lib/export/exportEvents.ts`
+- `ExportOptionsSchema` type: `lib/network-exporters/utils/types.ts:56-66`
+
+- [ ] **Step 1: Create the provider**
+
+```typescript
+// components/ExportProgressProvider.tsx
+'use client';
+
+import posthog from 'posthog-js';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+} from 'react';
+import { updateExportTime } from '~/actions/interviews';
+import { deleteZipFromUploadThing } from '~/actions/uploadThing';
+import ProgressBar from '~/components/ui/ProgressBar';
+import { useToast } from '~/components/ui/Toast';
+import { useDownload } from '~/hooks/useDownload';
+import type { ExportEvent } from '~/lib/export/exportEvents';
+import type { ExportOptions } from '~/lib/network-exporters/utils/types';
+import { ensureError } from '~/utils/ensureError';
+
+type ExportContextValue = {
+  startExport: (interviewIds: string[], exportOptions: ExportOptions) => void;
+};
+
+const ExportContext = createContext<ExportContextValue | null>(null);
+
+export function useExportProgress() {
+  const ctx = useContext(ExportContext);
+  if (!ctx) {
+    throw new Error('useExportProgress must be used within ExportProgressProvider');
+  }
+  return ctx;
+}
+
+function ExportProgressDescription({
+  stage,
+  message,
+  current,
+  total,
+}: {
+  stage: string;
+  message: string;
+  current?: number;
+  total?: number;
+}) {
+  const showProgress = stage === 'generating' && total !== undefined && total > 0;
+  const percent = showProgress && current !== undefined
+    ? Math.round((current / total) * 100)
+    : 0;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm opacity-60">
+        {showProgress ? `${message} ${current} / ${total}` : message}
+      </p>
+      {showProgress && (
+        <ProgressBar
+          orientation="horizontal"
+          percentProgress={percent}
+          nudge={false}
+          label="Export progress"
+          className="h-1.5"
+        />
+      )}
+    </div>
+  );
+}
+
+export function ExportProgressProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { add, update, close } = useToast();
+  const download = useDownload();
+  const abortControllers = useRef(new Map<string, AbortController>());
+
+  const cancelExport = useCallback(
+    (toastId: string) => {
+      const controller = abortControllers.current.get(toastId);
+      controller?.abort();
+      abortControllers.current.delete(toastId);
+      close(toastId);
+    },
+    [close],
+  );
+
+  const startExport = useCallback(
+    (interviewIds: string[], exportOptions: ExportOptions) => {
+      const controller = new AbortController();
+
+      const toastId = add({
+        title: 'Exporting interviews',
+        description: (
+          <ExportProgressDescription
+            stage="fetching"
+            message="Starting export..."
+          />
+        ),
+        type: 'loading',
+        timeout: 0,
+        onClose: () => cancelExport(toastId),
+        onCancel: () => cancelExport(toastId),
+      });
+
+      abortControllers.current.set(toastId, controller);
+
+      void (async () => {
+        try {
+          const response = await fetch('/api/export-interviews', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ interviewIds, exportOptions }),
+            signal: controller.signal,
+          });
+
+          if (!response.ok || !response.body) {
+            throw new Error(
+              `Export request failed with status ${String(response.status)}`,
+            );
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const events = buffer.split('\n\n');
+            buffer = events.pop() ?? '';
+
+            for (const event of events) {
+              const dataLine = event
+                .split('\n')
+                .find((line) => line.startsWith('data: '));
+              if (!dataLine) continue;
+
+              const data = JSON.parse(dataLine.slice(6)) as ExportEvent;
+
+              if (data.type === 'stage' || data.type === 'progress') {
+                update(toastId, {
+                  description: (
+                    <ExportProgressDescription
+                      stage={data.stage}
+                      message={
+                        data.type === 'stage' ? data.message : 'Generating files...'
+                      }
+                      current={'current' in data ? data.current : undefined}
+                      total={'total' in data ? data.total : undefined}
+                    />
+                  ),
+                });
+              } else if (data.type === 'complete') {
+                // Download the zip
+                const responseAsBlob = await fetch(data.zipUrl).then((res) => {
+                  if (!res.ok) throw new Error('HTTP error ' + String(res.status));
+                  return res.blob();
+                });
+
+                const url = URL.createObjectURL(responseAsBlob);
+                download(url, 'Network Canvas Export.zip');
+                URL.revokeObjectURL(url);
+
+                // Update export timestamps
+                await updateExportTime(interviewIds);
+
+                // Transition toast to success
+                update(toastId, {
+                  title: 'Export complete!',
+                  description: 'Your download should start automatically.',
+                  type: 'success',
+                  timeout: 5000,
+                });
+
+                // Cleanup: delete zip from UploadThing
+                void deleteZipFromUploadThing(data.zipKey).catch((error) => {
+                  const e = ensureError(error);
+                  posthog.captureException(e);
+
+                  add({
+                    timeout: Infinity,
+                    type: 'destructive',
+                    title: 'Could not delete temporary file',
+                    description:
+                      'We were unable to delete the temporary file containing your exported data, which is stored on your UploadThing account. Although extremely unlikely, it is possible that this file could be accessed by someone else. You can delete the file manually by visiting uploadthing.com and logging in with your GitHub account. Please contact us to report this issue.',
+                  });
+                });
+              } else if (data.type === 'error') {
+                update(toastId, {
+                  title: 'Export failed',
+                  description: data.message,
+                  type: 'destructive',
+                  timeout: 0,
+                });
+
+                posthog.captureException(new Error(data.message));
+              }
+            }
+          }
+        } catch (error) {
+          if (controller.signal.aborted) return;
+
+          const e = ensureError(error);
+          update(toastId, {
+            title: 'Export failed',
+            description: e.message,
+            type: 'destructive',
+            timeout: 0,
+          });
+
+          posthog.captureException(e);
+        } finally {
+          abortControllers.current.delete(toastId);
+        }
+      })();
+    },
+    [add, update, close, download, cancelExport],
+  );
+
+  return (
+    <ExportContext value={{ startExport }}>
+      {children}
+    </ExportContext>
+  );
+}
+```
+
+Note: The `onClose` and `onCancel` properties on the toast need to match what was implemented in Task 6. The implementer should verify the exact API surface for threading these callbacks through `@base-ui/react` toast's `data` property. If `onClose` is a native base-ui toast option, use it directly. Otherwise, thread it via the `data` field.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write components/ExportProgressProvider.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ExportProgressProvider.tsx
+git commit -m "feat: add ExportProgressProvider for managing export progress toasts"
+```
+
+---
+
+### Task 8: Wire Up Dashboard Layout
+
+Add the `ExportProgressProvider` to the dashboard layout so it persists across page navigation.
+
+**Files:**
+- Modify: `app/dashboard/layout.tsx`
+
+**Reference:**
+- Current layout: `app/dashboard/layout.tsx:14-28`
+- The layout is a Server Component, so `ExportProgressProvider` (a client component) wraps the children
+
+- [ ] **Step 1: Add ExportProgressProvider to the layout**
+
+Modify `app/dashboard/layout.tsx`:
+
+Add import:
+```typescript
+import { ExportProgressProvider } from '~/components/ExportProgressProvider';
+```
+
+Wrap `{children}` (line 24) with the provider:
+```tsx
+<ExportProgressProvider>
+  {children}
+</ExportProgressProvider>
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write app/dashboard/layout.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/dashboard/layout.tsx
+git commit -m "feat: add ExportProgressProvider to dashboard layout"
+```
+
+---
+
+### Task 9: Update ExportInterviewsDialog
+
+Replace the direct server action call with `startExport()` from the context. The dialog closes immediately after starting the export.
+
+**Files:**
+- Modify: `app/dashboard/interviews/_components/ExportInterviewsDialog.tsx`
+
+**Reference:**
+- Current dialog: `ExportInterviewsDialog.tsx:1-151`
+- `useExportProgress` hook from `components/ExportProgressProvider.tsx`
+
+- [ ] **Step 1: Rewrite the dialog**
+
+Replace the entire content of `ExportInterviewsDialog.tsx`:
+
+```typescript
+import { useExportProgress } from '~/components/ExportProgressProvider';
+import { Button } from '~/components/ui/Button';
+import useSafeLocalStorage from '~/hooks/useSafeLocalStorage';
+import type { Interview } from '~/lib/db/generated/client';
+import Dialog from '~/lib/dialogs/Dialog';
+import { ExportOptionsSchema } from '~/lib/network-exporters/utils/types';
+import ExportOptionsView from './ExportOptionsView';
+
+export const ExportInterviewsDialog = ({
+  open,
+  handleCancel,
+  interviewsToExport,
+}: {
+  open: boolean;
+  handleCancel: () => void;
+  interviewsToExport: Interview[];
+}) => {
+  const { startExport } = useExportProgress();
+
+  const [exportOptions, setExportOptions] = useSafeLocalStorage(
+    'exportOptions',
+    ExportOptionsSchema,
+    {
+      exportCSV: true,
+      exportGraphML: true,
+      globalOptions: {
+        useScreenLayoutCoordinates: true,
+        screenLayoutHeight: 1080,
+        screenLayoutWidth: 1920,
+      },
+    },
+  );
+
+  const handleConfirm = () => {
+    const interviewIds = interviewsToExport.map((interview) => interview.id);
+    startExport(interviewIds, exportOptions);
+    handleCancel(); // Close the dialog immediately
+  };
+
+  return (
+    <Dialog
+      open={open}
+      closeDialog={handleCancel}
+      title="Confirm File Export Options"
+      description="Before exporting, please confirm the export options that you wish to use. These options are identical to those found in Interviewer."
+      footer={
+        <>
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button onClick={handleConfirm} color="primary">
+            Start export process
+          </Button>
+        </>
+      }
+    >
+      <ExportOptionsView
+        exportOptions={exportOptions}
+        setExportOptions={setExportOptions}
+      />
+    </Dialog>
+  );
+};
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run formatter**
+
+Run: `pnpm prettier --write app/dashboard/interviews/_components/ExportInterviewsDialog.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/dashboard/interviews/_components/ExportInterviewsDialog.tsx
+git commit -m "refactor: delegate export to ExportProgressProvider, close dialog immediately"
+```
+
+---
+
+### Task 10: Remove `exportInterviews` Server Action
+
+The `exportInterviews` function in `actions/interviews.ts` is replaced by the route handler. Remove it and clean up unused imports.
+
+**Files:**
+- Modify: `actions/interviews.ts:84-120`
+
+**Reference:**
+- `exportInterviews` function: `actions/interviews.ts:84-120`
+- Imports to remove (if no longer used by other functions in this file): `Effect` (line 4), `ExportLayer` (line 9), `exportPipeline` (line 10), `ExportOptions`/`ExportReturn` types (line 13-14), `captureEvent`/`captureException`/`shutdownPostHog` (line 17-19)
+
+- [ ] **Step 1: Remove `exportInterviews` and unused imports**
+
+Delete the `exportInterviews` function (lines 84-120). Then check which imports are now unused:
+- `Effect` — check if `createInterview` uses it (it doesn't) → remove
+- `after` from `next/server` — still used by `createInterview` → keep
+- `ExportLayer`, `exportPipeline` → remove
+- `ExportOptions`, `ExportReturn` types → remove
+- `captureEvent`, `captureException`, `shutdownPostHog` — still used by `createInterview` → keep
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors. If other files import `exportInterviews` from this module, they will error — but the dialog was updated in Task 9 to not import it.
+
+- [ ] **Step 3: Run linter to check for unused imports**
+
+Run: `pnpm lint --fix`
+Expected: Auto-fixes any remaining unused imports
+
+- [ ] **Step 4: Run formatter**
+
+Run: `pnpm prettier --write actions/interviews.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/interviews.ts
+git commit -m "refactor: remove exportInterviews server action (replaced by route handler)"
+```
+
+---
+
+### Task 11: Manual Testing & Integration Verification
+
+Verify the full flow works end-to-end in the development environment.
+
+**Files:** None (testing only)
+
+**Prerequisites:** The user must have the dev server running (`pnpm dev`). Ask them to start it if needed.
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 2: Run full linter**
+
+Run: `pnpm lint`
+Expected: No errors
+
+- [ ] **Step 3: Run all unit tests**
+
+Run: `pnpm test`
+Expected: All tests pass
+
+- [ ] **Step 4: Manual testing checklist**
+
+Using the browser (or Playwright MCP if available), verify:
+
+1. Navigate to Dashboard → Interviews
+2. Click "Export Interview Data" → "Export all interviews"
+3. Export options dialog appears
+4. Click "Start export process"
+5. Dialog closes immediately
+6. A persistent toast appears in bottom-right with spinner + stage label
+7. Toast updates through stages: Fetching → Formatting → Generating (with progress bar + count) → Archiving → Uploading
+8. On complete: zip file downloads, toast transitions to green "Export complete!" and auto-dismisses
+9. Verify the "Cancel" button in the toast works (start another export, click Cancel, toast disappears, no download)
+10. Verify closing the toast (X button) also cancels the export
+11. Verify concurrent exports: start two exports, both show progress toasts simultaneously
+
+- [ ] **Step 5: Verify storybook**
+
+Run: `pnpm storybook` (ask user to start if needed)
+Navigate to Components → Toast → Loading story
+Verify the simulated export progress animation works
+
+- [ ] **Step 6: Final commit if any adjustments were needed**
+
+```bash
+git add -A
+git commit -m "fix: integration adjustments from manual testing"
+```

--- a/docs/superpowers/specs/2026-03-18-export-progress-feedback-design.md
+++ b/docs/superpowers/specs/2026-03-18-export-progress-feedback-design.md
@@ -40,7 +40,9 @@ data: {"type":"error","message":"Something went wrong"}
 
 The export pipeline (`lib/export/pipeline.ts`) is modified to accept an `Effect.Queue` and push progress events to it between steps.
 
-The file generation step (`generateOutputFiles`) is converted from `Promise.all` to `Effect.forEach` with `{ concurrency: "unbounded" }`. Per-file completion is tracked via `Effect.Ref` and reported to the queue via `Effect.tap`.
+The file generation step (`generateOutputFiles`) becomes an Effect-returning function (no longer wrapped in `Effect.tryPromise`). Its internals are converted from building an array of Promises and using `Promise.all` to using `Effect.forEach` with `{ concurrency: "unbounded" }`. Each file export is wrapped as an Effect via `Effect.tryPromise`, and per-file completion is tracked via `Effect.Ref` and reported to the queue via `Effect.tap`. The function signature changes from a curried async function to an Effect, and its callsite in `pipeline.ts` updates accordingly (direct `yield*` instead of wrapping in `Effect.tryPromise`).
+
+The `total` file count is computed eagerly before invoking `Effect.forEach` — the existing code already builds the full list of export items (sessions x formats x entity types) before executing them. This count is sent with the initial `stage: 'generating'` event so the client knows the total from the start.
 
 The SSE stream is modeled as:
 
@@ -71,7 +73,9 @@ A React context provider that lives in the dashboard layout (`app/dashboard/layo
 8. As SSE events arrive, the toast is updated via `toast.update(id, ...)`
 9. On complete: zip is fetched and downloaded automatically, toast transitions to success and auto-dismisses after 5 seconds
 10. On error: toast transitions to error state and stays until dismissed
-11. Cleanup: temporary zip file is deleted from UploadThing after download
+11. After successful download: `updateExportTime` server action is called to update interview export timestamps
+12. Cleanup: temporary zip file is deleted from UploadThing after download
+13. PostHog event tracking: client-side `posthog.captureException` on error, preserved from existing flow
 
 #### Cancellation
 
@@ -88,7 +92,7 @@ Multiple exports can run simultaneously. Each gets its own toast, SSE connection
 
 The existing `@base-ui/react` toast system supports everything needed:
 
-- `timeout: 0` or `type: 'loading'` makes a toast persistent
+- `timeout: 0` makes a toast persistent (never auto-dismisses). Note: `type` is purely a visual variant and does not affect persistence — always set `timeout: 0` explicitly for persistent toasts.
 - `update(id, data)` modifies title, description, type, and timeout on an existing toast
 - `close(id)` dismisses a specific toast
 
@@ -102,7 +106,7 @@ The progress toast description is a React node containing the stage label text, 
 
 #### Toast States
 
-**During export (persistent, `type: 'loading'`):**
+**During export (persistent, `type: 'loading'`, `timeout: 0`):**
 
 - Early stages (fetching, formatting, archiving, uploading): spinner + stage label + cancel button
 - Generating stage: spinner + "Generating files... X / Y" + horizontal progress bar + cancel button
@@ -123,7 +127,7 @@ The progress toast description is a React node containing the stage label text, 
 |------|---------|
 | `app/api/export-interviews/route.ts` | SSE route handler |
 | `components/ExportProgressProvider.tsx` | React context for managing active exports |
-| `schemas/export.ts` | Zod schema for route handler request body |
+| `schemas/export.ts` | Zod schema for route handler request body (reuses `ExportOptionsSchema` from `~/lib/network-exporters/utils/types`) |
 
 ### Modified
 

--- a/docs/superpowers/specs/2026-03-18-export-progress-feedback-design.md
+++ b/docs/superpowers/specs/2026-03-18-export-progress-feedback-design.md
@@ -1,0 +1,150 @@
+# Export Progress Feedback
+
+## Overview
+
+Add real-time progress feedback to the interview data export process. When a user starts an export, the dialog closes immediately and a persistent toast shows pipeline progress — stage labels, per-file counts during file generation, and a progress bar. The user can continue navigating the dashboard while the export runs. Multiple concurrent exports are supported.
+
+## Architecture
+
+### SSE Route Handler
+
+A new route handler at `/api/export-interviews` replaces the `exportInterviews` server action for running the export pipeline. It streams Server-Sent Events (SSE) as the pipeline progresses, following the same pattern as `/api/generate-test-interviews`.
+
+The route handler:
+
+1. Authenticates with `requireApiAuth()`
+2. Validates the request body against a Zod schema (interview IDs + export options)
+3. Runs the export pipeline as an Effect program that pushes events to an `Effect.Queue`
+4. Converts the queue to an `Effect.Stream`, maps events to SSE-formatted text, and produces the response via `Stream.toReadableStream`
+5. Uses `safeRevalidateTag` for cache invalidation (route handler context)
+
+### SSE Event Protocol
+
+```
+data: {"type":"stage","stage":"fetching","message":"Fetching interview data..."}
+data: {"type":"stage","stage":"formatting","message":"Formatting sessions..."}
+data: {"type":"stage","stage":"generating","message":"Generating files...","current":0,"total":18}
+data: {"type":"progress","stage":"generating","current":5,"total":18}
+data: {"type":"stage","stage":"archiving","message":"Creating archive..."}
+data: {"type":"stage","stage":"uploading","message":"Uploading..."}
+data: {"type":"complete","zipUrl":"https://...","zipKey":"networkCanvasExport-123.zip"}
+data: {"type":"error","message":"Something went wrong"}
+```
+
+- `stage` events mark transitions between pipeline phases
+- `progress` events provide per-file granularity within the generating stage
+- `complete` returns the zip URL/key for the client to trigger download
+- `error` communicates failures
+
+### Pipeline Changes
+
+The export pipeline (`lib/export/pipeline.ts`) is modified to accept an `Effect.Queue` and push progress events to it between steps.
+
+The file generation step (`generateOutputFiles`) is converted from `Promise.all` to `Effect.forEach` with `{ concurrency: "unbounded" }`. Per-file completion is tracked via `Effect.Ref` and reported to the queue via `Effect.tap`.
+
+The SSE stream is modeled as:
+
+```
+Queue (pipeline pushes events) → Stream.fromQueue → Stream.map (SSE format) → Stream.toReadableStream → Response
+```
+
+The pipeline and stream consumer run as concurrent Effect fibers. Cancellation is handled by Effect's fiber interruption — when the client disconnects, the stream closes, which interrupts the pipeline fiber.
+
+### Client-Side Architecture
+
+#### ExportProgressProvider
+
+A React context provider that lives in the dashboard layout (`app/dashboard/layout.tsx`). It manages active exports and provides:
+
+- `startExport(interviewIds, exportOptions)` — kicks off the SSE fetch, creates the progress toast, returns immediately
+- Internally manages an `AbortController` per export for cancellation
+
+#### Flow
+
+1. User selects interviews and clicks export
+2. Export options dialog opens (unchanged)
+3. User clicks "Start export process"
+4. Dialog closes immediately
+5. `startExport()` is called from the context
+6. A persistent toast appears showing the current pipeline stage
+7. User can navigate the dashboard freely
+8. As SSE events arrive, the toast is updated via `toast.update(id, ...)`
+9. On complete: zip is fetched and downloaded automatically, toast transitions to success and auto-dismisses after 5 seconds
+10. On error: toast transitions to error state and stays until dismissed
+11. Cleanup: temporary zip file is deleted from UploadThing after download
+
+#### Cancellation
+
+- Each progress toast has a dedicated "Cancel" button in the toast body
+- The toast's `onClose` callback also aborts the export (closing = cancelling)
+- Aborting the `AbortController` closes the SSE stream
+- The route handler detects disconnection via Effect fiber interruption and cleans up temp files
+
+#### Concurrent Exports
+
+Multiple exports can run simultaneously. Each gets its own toast, SSE connection, and AbortController. No race conditions — each export uses its own temp directory and unique zip filename.
+
+### Toast System Changes
+
+The existing `@base-ui/react` toast system supports everything needed:
+
+- `timeout: 0` or `type: 'loading'` makes a toast persistent
+- `update(id, data)` modifies title, description, type, and timeout on an existing toast
+- `close(id)` dismisses a specific toast
+
+Changes to `components/ui/Toast.tsx`:
+
+- Add `loading` variant to `toastVariants` CVA config (styling)
+- Add a spinner icon to `variantIcons` for the `loading` type
+- Add support for a cancel action button in the toast body (via `ToastData`)
+
+The progress toast description is a React node containing the stage label text, and during the generating stage, an inline `ProgressBar` component.
+
+#### Toast States
+
+**During export (persistent, `type: 'loading'`):**
+
+- Early stages (fetching, formatting, archiving, uploading): spinner + stage label + cancel button
+- Generating stage: spinner + "Generating files... X / Y" + horizontal progress bar + cancel button
+
+**On success (`type: 'success'`, `timeout: 5000`):**
+
+- "Export complete!" with "Your download should start automatically."
+
+**On error (`type: 'destructive'`, `timeout: 0`):**
+
+- "Export failed" with error message, stays until dismissed
+
+## Files Changed
+
+### New
+
+| File | Purpose |
+|------|---------|
+| `app/api/export-interviews/route.ts` | SSE route handler |
+| `components/ExportProgressProvider.tsx` | React context for managing active exports |
+| `schemas/export.ts` | Zod schema for route handler request body |
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `lib/export/pipeline.ts` | Accept `Effect.Queue`, push stage/progress events |
+| `lib/network-exporters/formatters/session/generateOutputFiles.ts` | Convert to `Effect.forEach` with concurrency, track per-file progress via `Ref` |
+| `app/dashboard/interviews/_components/ExportInterviewsDialog.tsx` | Replace server action call with `startExport()` from context, close immediately |
+| `app/dashboard/layout.tsx` | Wrap children in `ExportProgressProvider` |
+| `components/ui/Toast.tsx` | Add `loading` variant, spinner icon, cancel button support |
+| `actions/interviews.ts` | Remove `exportInterviews` server action (replaced by route handler). `updateExportTime` stays. |
+
+### Unchanged
+
+- `lib/export/services/*`, `lib/export/layers/*`, `lib/export/errors.ts` — service abstractions
+- `lib/network-exporters/formatters/*` (except `generateOutputFiles`) — formatters
+- `app/dashboard/_components/InterviewsTable/InterviewsTable.tsx` — delegates to dialog, no changes needed
+
+## Testing
+
+- Unit tests for the modified `generateOutputFiles` Effect pipeline
+- Unit tests for `ExportProgressProvider` (mock SSE, verify toast lifecycle)
+- Storybook story for the toast loading variant with progress bar
+- E2E test: trigger export, verify progress toast appears, verify download completes

--- a/lib/export/__tests__/exportEvents.test.ts
+++ b/lib/export/__tests__/exportEvents.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { formatSSE, type ExportEvent } from '~/lib/export/exportEvents';
+
+describe('formatSSE', () => {
+  it('formats a stage event as SSE', () => {
+    const event: ExportEvent = {
+      type: 'stage',
+      stage: 'fetching',
+      message: 'Fetching interview data...',
+    };
+    const result = formatSSE(event);
+    expect(result).toBe(
+      'data: {"type":"stage","stage":"fetching","message":"Fetching interview data..."}\n\n',
+    );
+  });
+
+  it('formats a progress event as SSE', () => {
+    const event: ExportEvent = {
+      type: 'progress',
+      stage: 'generating',
+      current: 3,
+      total: 10,
+    };
+    const result = formatSSE(event);
+    expect(result).toContain('"type":"progress"');
+    expect(result).toContain('"current":3');
+    expect(result).toContain('"total":10');
+    expect(result.startsWith('data: ')).toBe(true);
+    expect(result.endsWith('\n\n')).toBe(true);
+  });
+
+  it('formats a complete event as SSE', () => {
+    const event: ExportEvent = {
+      type: 'complete',
+      zipUrl: 'https://example.com/export.zip',
+      zipKey: 'networkCanvasExport-123.zip',
+    };
+    const result = formatSSE(event);
+    expect(result).toContain('"type":"complete"');
+    expect(result).toContain('"zipUrl":"https://example.com/export.zip"');
+    expect(result.startsWith('data: ')).toBe(true);
+    expect(result.endsWith('\n\n')).toBe(true);
+  });
+
+  it('formats an error event as SSE', () => {
+    const event: ExportEvent = {
+      type: 'error',
+      message: 'Something went wrong',
+    };
+    const result = formatSSE(event);
+    expect(result).toContain('"type":"error"');
+    expect(result).toContain('"message":"Something went wrong"');
+  });
+});

--- a/lib/export/__tests__/pipeline.test.ts
+++ b/lib/export/__tests__/pipeline.test.ts
@@ -5,7 +5,10 @@ import type { ExportEvent } from '~/lib/export/exportEvents';
 import { NodeFileSystem } from '~/lib/export/layers/NodeFileSystem';
 import { exportPipeline } from '~/lib/export/pipeline';
 import { FileStorage } from '~/lib/export/services/FileStorage';
-import { InterviewRepository } from '~/lib/export/services/InterviewRepository';
+import {
+  InterviewRepository,
+  type InterviewExportData,
+} from '~/lib/export/services/InterviewRepository';
 
 const defaultExportOptions = {
   exportGraphML: true,
@@ -87,5 +90,98 @@ describe('exportPipeline', () => {
     const stageEvents = [...events].filter((e) => e.type === 'stage');
     expect(stageEvents.length).toBeGreaterThanOrEqual(1);
     expect(stageEvents[0]?.stage).toBe('fetching');
+  });
+
+  it('emits all stage events in order on successful export', async () => {
+    const mockInterview: InterviewExportData = {
+      id: 'test-interview-1',
+      startTime: new Date('2025-01-01'),
+      finishTime: new Date('2025-01-01'),
+      exportTime: null,
+      lastUpdated: new Date('2025-01-01'),
+      participantId: 'participant-1',
+      protocolId: 'proto-1',
+      currentStep: 0,
+      stageMetadata: null,
+      isSynthetic: false,
+      network: {
+        nodes: [],
+        edges: [],
+        ego: { _uid: 'ego-1', attributes: {} },
+      },
+      protocol: {
+        id: 'proto-1',
+        hash: 'testhash123',
+        name: 'Test Protocol',
+        schemaVersion: 7,
+        description: null,
+        importedAt: new Date('2025-01-01'),
+        lastModified: new Date('2025-01-01'),
+        stages: [],
+        codebook: {
+          node: {},
+          edge: {},
+          ego: {},
+        },
+        experiments: {},
+      },
+      participant: {
+        id: 'participant-1',
+        identifier: 'test-participant',
+        label: 'Test Participant',
+        isSynthetic: false,
+      },
+    };
+
+    const MockRepo = Layer.succeed(InterviewRepository, {
+      getForExport: () => Effect.succeed([mockInterview]),
+    });
+
+    const MockStorage = Layer.succeed(FileStorage, {
+      upload: () =>
+        Effect.succeed({
+          url: 'http://test/file.zip',
+          key: 'networkCanvasExport-123.zip',
+        }),
+      delete: () => Effect.void,
+    });
+
+    const testLayer = Layer.mergeAll(MockRepo, NodeFileSystem, MockStorage);
+
+    const { result, events } = await Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<ExportEvent>();
+
+      const pipelineResult = yield* exportPipeline(
+        ['test-interview-1'],
+        defaultExportOptions,
+        queue,
+      ).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            status: 'error' as const,
+            error: 'userMessage' in error ? error.userMessage : 'Unknown',
+          }),
+        ),
+      );
+
+      const allEvents = yield* Queue.takeAll(queue);
+      return { result: pipelineResult, events: [...allEvents] };
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
+
+    const stageEvents = events.filter((e) => e.type === 'stage');
+    const stageOrder = stageEvents.map((e) => {
+      if (e.type === 'stage') return e.stage;
+      return '';
+    });
+
+    expect(stageOrder).toEqual([
+      'fetching',
+      'formatting',
+      'generating',
+      'archiving',
+      'uploading',
+    ]);
+
+    expect(result.status).not.toBe('error');
   });
 });

--- a/lib/export/__tests__/pipeline.test.ts
+++ b/lib/export/__tests__/pipeline.test.ts
@@ -1,6 +1,7 @@
-import { Effect, Layer } from 'effect';
+import { Effect, Layer, Queue } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { DatabaseError } from '~/lib/export/errors';
+import type { ExportEvent } from '~/lib/export/exportEvents';
 import { NodeFileSystem } from '~/lib/export/layers/NodeFileSystem';
 import { exportPipeline } from '~/lib/export/pipeline';
 import { FileStorage } from '~/lib/export/services/FileStorage';
@@ -35,18 +36,56 @@ describe('exportPipeline', () => {
 
     const testLayer = Layer.mergeAll(MockRepo, NodeFileSystem, MockStorage);
 
-    const result = await exportPipeline(['test-id'], defaultExportOptions).pipe(
-      Effect.catchAll((error) =>
-        Effect.succeed({
-          status: 'error' as const,
-          error: error.userMessage,
-        }),
-      ),
-      Effect.provide(testLayer),
-      Effect.runPromise,
-    );
+    const result = await Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<ExportEvent>();
+      return yield* exportPipeline(
+        ['test-id'],
+        defaultExportOptions,
+        queue,
+      ).pipe(
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            status: 'error' as const,
+            error: error.userMessage,
+          }),
+        ),
+      );
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
 
     expect(result.status).toBe('error');
     expect(result.error).toBe('Database connection failed.');
+  });
+
+  it('emits stage events to the queue', async () => {
+    const MockRepo = Layer.succeed(InterviewRepository, {
+      getForExport: () =>
+        Effect.fail(
+          new DatabaseError({
+            cause: new Error('test'),
+            userMessage: 'Test error.',
+          }),
+        ),
+    });
+
+    const MockStorage = Layer.succeed(FileStorage, {
+      upload: () => Effect.succeed({ url: 'http://test/file.zip', key: 'k' }),
+      delete: () => Effect.void,
+    });
+
+    const testLayer = Layer.mergeAll(MockRepo, NodeFileSystem, MockStorage);
+
+    const events = await Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<ExportEvent>();
+
+      yield* exportPipeline(['test-id'], defaultExportOptions, queue).pipe(
+        Effect.catchAll(() => Effect.void),
+      );
+
+      return yield* Queue.takeAll(queue);
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
+
+    const stageEvents = [...events].filter((e) => e.type === 'stage');
+    expect(stageEvents.length).toBeGreaterThanOrEqual(1);
+    expect(stageEvents[0]?.stage).toBe('fetching');
   });
 });

--- a/lib/export/exportEvents.ts
+++ b/lib/export/exportEvents.ts
@@ -1,12 +1,9 @@
-const exportStages = [
-  'fetching',
-  'formatting',
-  'generating',
-  'archiving',
-  'uploading',
-] as const;
-
-type ExportStage = (typeof exportStages)[number];
+type ExportStage =
+  | 'fetching'
+  | 'formatting'
+  | 'generating'
+  | 'archiving'
+  | 'uploading';
 
 export const stageMessages: Record<ExportStage, string> = {
   fetching: 'Fetching interview data...',

--- a/lib/export/exportEvents.ts
+++ b/lib/export/exportEvents.ts
@@ -1,4 +1,4 @@
-export const exportStages = [
+const exportStages = [
   'fetching',
   'formatting',
   'generating',
@@ -6,7 +6,7 @@ export const exportStages = [
   'uploading',
 ] as const;
 
-export type ExportStage = (typeof exportStages)[number];
+type ExportStage = (typeof exportStages)[number];
 
 export const stageMessages: Record<ExportStage, string> = {
   fetching: 'Fetching interview data...',

--- a/lib/export/exportEvents.ts
+++ b/lib/export/exportEvents.ts
@@ -1,0 +1,53 @@
+export const exportStages = [
+  'fetching',
+  'formatting',
+  'generating',
+  'archiving',
+  'uploading',
+] as const;
+
+export type ExportStage = (typeof exportStages)[number];
+
+export const stageMessages: Record<ExportStage, string> = {
+  fetching: 'Fetching interview data...',
+  formatting: 'Formatting sessions...',
+  generating: 'Generating files...',
+  archiving: 'Creating archive...',
+  uploading: 'Uploading...',
+};
+
+export type ExportStageEvent = {
+  type: 'stage';
+  stage: ExportStage;
+  message: string;
+  current?: number;
+  total?: number;
+};
+
+export type ExportProgressEvent = {
+  type: 'progress';
+  stage: 'generating';
+  current: number;
+  total: number;
+};
+
+export type ExportCompleteEvent = {
+  type: 'complete';
+  zipUrl: string;
+  zipKey: string;
+};
+
+export type ExportErrorEvent = {
+  type: 'error';
+  message: string;
+};
+
+export type ExportEvent =
+  | ExportStageEvent
+  | ExportProgressEvent
+  | ExportCompleteEvent
+  | ExportErrorEvent;
+
+export function formatSSE(event: ExportEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}

--- a/lib/export/pipeline.ts
+++ b/lib/export/pipeline.ts
@@ -1,7 +1,7 @@
 import { basename } from 'node:path';
-import { Effect } from 'effect';
+import { Effect, Queue } from 'effect';
 import archive from '~/lib/network-exporters/formatters/session/archive';
-import { generateOutputFiles } from '~/lib/network-exporters/formatters/session/generateOutputFiles';
+import { generateOutputFilesEffect } from '~/lib/network-exporters/formatters/session/generateOutputFiles';
 import { formatExportableSessions } from '~/lib/network-exporters/formatters/formatExportableSessions';
 import groupByProtocolProperty from '~/lib/network-exporters/formatters/session/groupByProtocolProperty';
 import { insertEgoIntoSessionNetworks } from '~/lib/network-exporters/formatters/session/insertEgoIntoSessionNetworks';
@@ -12,10 +12,10 @@ import type {
 } from '~/lib/network-exporters/utils/types';
 import {
   ArchiveError,
-  ExportGenerationError,
   FileStorageError,
   getUserMessage,
 } from '~/lib/export/errors';
+import { type ExportEvent, stageMessages } from '~/lib/export/exportEvents';
 import { FileStorage } from '~/lib/export/services/FileStorage';
 import { FileSystem } from '~/lib/export/services/FileSystem';
 import {
@@ -38,15 +38,28 @@ function buildProtocolsMap(
 export const exportPipeline = (
   interviewIds: string[],
   exportOptions: ExportOptions,
+  progressQueue: Queue.Queue<ExportEvent>,
 ) =>
   Effect.gen(function* () {
     const repo = yield* InterviewRepository;
     const fs = yield* FileSystem;
     const fileStorage = yield* FileStorage;
 
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'fetching',
+      message: stageMessages.fetching,
+    });
+
     const sessions = yield* repo
       .getForExport(interviewIds)
       .pipe(Effect.withSpan('export.fetch'));
+
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'formatting',
+      message: stageMessages.formatting,
+    });
 
     const protocols = buildProtocolsMap(sessions);
     const formatted = formatExportableSessions(sessions);
@@ -54,18 +67,22 @@ export const exportPipeline = (
     const grouped = groupByProtocolProperty(withEgo);
     const resequenced = resequenceIds(grouped);
 
-    const exportResults = yield* Effect.tryPromise({
-      try: () => generateOutputFiles(protocols, exportOptions)(resequenced),
-      catch: (error) =>
-        new ExportGenerationError({
-          cause: error,
-          userMessage: getUserMessage(error, 'generating export files'),
-        }),
-    }).pipe(Effect.withSpan('export.generateFiles'));
+    const exportResults = yield* generateOutputFilesEffect(
+      protocols,
+      exportOptions,
+      resequenced,
+      progressQueue,
+    ).pipe(Effect.withSpan('export.generateFiles'));
 
     const tempFilePaths = exportResults
       .filter((r): r is Extract<typeof r, { success: true }> => r.success)
       .map((r) => r.filePath);
+
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'archiving',
+      message: stageMessages.archiving,
+    });
 
     const archiveResult = yield* Effect.tryPromise({
       try: () => archive(exportResults),
@@ -87,6 +104,12 @@ export const exportPipeline = (
         }),
       );
     }
+
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'uploading',
+      message: stageMessages.uploading,
+    });
 
     const archiveBuffer = yield* fs.readFile(archiveResult.path);
     const { url, key } = yield* fileStorage

--- a/lib/interviewer/components/InterviewToast.tsx
+++ b/lib/interviewer/components/InterviewToast.tsx
@@ -42,7 +42,6 @@ const arrowVariants = cva({
       info: 'bg-info',
       success: 'bg-success',
       destructive: 'bg-destructive',
-      loading: 'bg-info',
     },
   },
   defaultVariants: {

--- a/lib/interviewer/components/InterviewToast.tsx
+++ b/lib/interviewer/components/InterviewToast.tsx
@@ -42,6 +42,7 @@ const arrowVariants = cva({
       info: 'bg-info',
       success: 'bg-success',
       destructive: 'bg-destructive',
+      loading: 'bg-info',
     },
   },
   defaultVariants: {

--- a/lib/network-exporters/formatters/session/generateOutputFiles.ts
+++ b/lib/network-exporters/formatters/session/generateOutputFiles.ts
@@ -1,56 +1,116 @@
+import { Effect, Queue, Ref } from 'effect';
 import { invariant } from 'es-toolkit';
+import { ExportGenerationError, getUserMessage } from '~/lib/export/errors';
+import type { ExportEvent } from '~/lib/export/exportEvents';
 import { type ExportedProtocol } from '~/lib/export/pipeline';
 import { getFilePrefix } from '../../utils/general';
 import type {
   ExportFormat,
   ExportOptions,
-  ExportResult,
   SessionWithResequencedIDs,
 } from '../../utils/types';
 import exportFile from './exportFile';
 import { partitionByType } from './partitionByType';
 
-export const generateOutputFiles =
-  (protocols: Record<string, ExportedProtocol>, exportOptions: ExportOptions) =>
-  async (unifiedSessions: Record<string, SessionWithResequencedIDs[]>) => {
-    const exportFormats = [
-      ...(exportOptions.exportGraphML ? ['graphml'] : []),
-      ...(exportOptions.exportCSV ? ['attributeList', 'edgeList', 'ego'] : []),
-    ] as ExportFormat[];
+type ExportItem = {
+  prefix: string;
+  exportFormat: ExportFormat;
+  network: ReturnType<typeof partitionByType>[number];
+  codebook: Parameters<typeof exportFile>[0]['codebook'];
+  exportOptions: ExportOptions;
+};
 
-    const exportPromises: Promise<ExportResult>[] = [];
+function buildExportItems(
+  protocols: Record<string, ExportedProtocol>,
+  exportOptions: ExportOptions,
+  unifiedSessions: Record<string, SessionWithResequencedIDs[]>,
+): ExportItem[] {
+  const exportFormats = [
+    ...(exportOptions.exportGraphML ? ['graphml'] : []),
+    ...(exportOptions.exportCSV ? ['attributeList', 'edgeList', 'ego'] : []),
+  ] as ExportFormat[];
 
-    Object.entries(unifiedSessions).forEach(([protocolKey, sessions]) => {
-      const codebook = protocols[protocolKey]?.codebook;
-      invariant(codebook, `No protocol found for key: ${protocolKey}`);
+  const items: ExportItem[] = [];
 
-      sessions.forEach((session) => {
-        const prefix = getFilePrefix(session);
+  Object.entries(unifiedSessions).forEach(([protocolKey, sessions]) => {
+    const codebook = protocols[protocolKey]?.codebook;
+    invariant(codebook, `No protocol found for key: ${protocolKey}`);
 
-        exportFormats.forEach((format) => {
-          // Split each network into separate files based on format and entity type.
-          const partitionedNetworks = partitionByType(
+    sessions.forEach((session) => {
+      const prefix = getFilePrefix(session);
+
+      exportFormats.forEach((format) => {
+        const partitionedNetworks = partitionByType(codebook, session, format);
+
+        partitionedNetworks.forEach((partitionedNetwork) => {
+          items.push({
+            prefix,
+            exportFormat: format,
+            network: partitionedNetwork,
             codebook,
-            session,
-            format,
-          );
-
-          partitionedNetworks.forEach((partitionedNetwork) => {
-            const exportPromise = exportFile({
-              prefix,
-              exportFormat: format,
-              network: partitionedNetwork,
-              codebook,
-              exportOptions,
-            });
-
-            exportPromises.push(exportPromise);
+            exportOptions,
           });
         });
       });
     });
+  });
 
-    const result = await Promise.all(exportPromises);
+  return items;
+}
 
+export const generateOutputFilesEffect = (
+  protocols: Record<string, ExportedProtocol>,
+  exportOptions: ExportOptions,
+  unifiedSessions: Record<string, SessionWithResequencedIDs[]>,
+  progressQueue: Queue.Queue<ExportEvent>,
+) =>
+  Effect.gen(function* () {
+    const items = buildExportItems(protocols, exportOptions, unifiedSessions);
+    const total = items.length;
+    const completedRef = yield* Ref.make(0);
+
+    yield* Queue.offer(progressQueue, {
+      type: 'stage',
+      stage: 'generating',
+      message: 'Generating files...',
+      current: 0,
+      total,
+    });
+
+    const results = yield* Effect.forEach(
+      items,
+      (item) =>
+        Effect.tryPromise({
+          try: () => exportFile(item),
+          catch: (error) =>
+            new ExportGenerationError({
+              cause: error,
+              userMessage: getUserMessage(error, 'generating export files'),
+            }),
+        }).pipe(
+          Effect.tap(() =>
+            Ref.updateAndGet(completedRef, (n) => n + 1).pipe(
+              Effect.tap((current) =>
+                Queue.offer(progressQueue, {
+                  type: 'progress',
+                  stage: 'generating',
+                  current,
+                  total,
+                }),
+              ),
+            ),
+          ),
+        ),
+      { concurrency: 'unbounded' },
+    );
+
+    return results;
+  });
+
+export const generateOutputFiles =
+  (protocols: Record<string, ExportedProtocol>, exportOptions: ExportOptions) =>
+  async (unifiedSessions: Record<string, SessionWithResequencedIDs[]>) => {
+    const items = buildExportItems(protocols, exportOptions, unifiedSessions);
+    const result = await Promise.all(items.map((item) => exportFile(item)));
     return result;
   };

--- a/lib/network-exporters/formatters/session/generateOutputFiles.ts
+++ b/lib/network-exporters/formatters/session/generateOutputFiles.ts
@@ -106,11 +106,3 @@ export const generateOutputFilesEffect = (
 
     return results;
   });
-
-export const generateOutputFiles =
-  (protocols: Record<string, ExportedProtocol>, exportOptions: ExportOptions) =>
-  async (unifiedSessions: Record<string, SessionWithResequencedIDs[]>) => {
-    const items = buildExportItems(protocols, exportOptions, unifiedSessions);
-    const result = await Promise.all(items.map((item) => exportFile(item)));
-    return result;
-  };

--- a/queries/interviews.ts
+++ b/queries/interviews.ts
@@ -8,14 +8,76 @@ import { prisma } from '~/lib/db';
  * Define the Prisma query logic for fetching all interviews separately
  * to infer the type from the return value.
  */
+type NetworkSummaryEntry = {
+  type: string;
+  count: number;
+};
+
+type InterviewNetworkSummary = {
+  nodes: NetworkSummaryEntry[];
+  edges: NetworkSummaryEntry[];
+};
+
+function summarizeNetwork(
+  network: Record<string, unknown> | null,
+): InterviewNetworkSummary {
+  if (!network) return { nodes: [], edges: [] };
+
+  const nodes = Array.isArray(network.nodes) ? network.nodes : [];
+  const edges = Array.isArray(network.edges) ? network.edges : [];
+
+  const countByType = (items: unknown[]): NetworkSummaryEntry[] => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      if (item === null || typeof item !== 'object') continue;
+      const type =
+        'type' in item && typeof item.type === 'string' ? item.type : 'unknown';
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([type, count]) => ({ type, count }));
+  };
+
+  return {
+    nodes: countByType(nodes),
+    edges: countByType(edges),
+  };
+}
+
 async function prisma_getInterviews() {
-  return prisma.interview.findMany({
-    include: {
-      protocol: true,
-      participant: true,
+  const interviews = await prisma.interview.findMany({
+    select: {
+      id: true,
+      startTime: true,
+      finishTime: true,
+      exportTime: true,
+      lastUpdated: true,
+      currentStep: true,
+      protocolId: true,
+      network: true,
+      isSynthetic: true,
+      participant: {
+        select: {
+          identifier: true,
+        },
+      },
+      protocol: {
+        select: {
+          name: true,
+          stages: true,
+          codebook: true,
+        },
+      },
     },
   });
+
+  return interviews.map((interview) => ({
+    ...interview,
+    network: summarizeNetwork(
+      interview.network as Record<string, unknown> | null,
+    ),
+  }));
 }
+
 export type GetInterviewsQuery = Awaited<
   ReturnType<typeof prisma_getInterviews>
 >;

--- a/queries/interviews.ts
+++ b/queries/interviews.ts
@@ -4,10 +4,6 @@ import { stringify } from 'superjson';
 import { safeCacheTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 
-/**
- * Define the Prisma query logic for fetching all interviews separately
- * to infer the type from the return value.
- */
 type NetworkSummaryEntry = {
   type: string;
   count: number;
@@ -20,94 +16,103 @@ type InterviewNetworkSummary = {
   edges: NetworkSummaryEntry[];
 };
 
-type CodebookLike = Record<
-  string,
-  Record<string, { name?: string; color?: string }> | undefined
->;
+type InterviewListRow = {
+  id: string;
+  startTime: Date;
+  finishTime: Date | null;
+  exportTime: Date | null;
+  lastUpdated: Date;
+  currentStep: number;
+  protocolId: string;
+  isSynthetic: boolean;
+  participant: { identifier: string };
+  protocol: { name: string; stageCount: number };
+  network: InterviewNetworkSummary;
+};
 
-function summarizeNetwork(
-  network: Record<string, unknown> | null,
-  codebook: CodebookLike | null,
-): InterviewNetworkSummary {
-  if (!network) return { nodes: [], edges: [] };
+type RawInterviewRow = {
+  id: string;
+  startTime: Date;
+  finishTime: Date | null;
+  exportTime: Date | null;
+  lastUpdated: Date;
+  currentStep: number;
+  protocolId: string;
+  isSynthetic: boolean;
+  participantIdentifier: string;
+  protocolName: string;
+  stageCount: number;
+  nodeSummary: NetworkSummaryEntry[];
+  edgeSummary: NetworkSummaryEntry[];
+};
 
-  const nodes = Array.isArray(network.nodes) ? network.nodes : [];
-  const edges = Array.isArray(network.edges) ? network.edges : [];
+async function prisma_getInterviews(): Promise<InterviewListRow[]> {
+  const rows = await prisma.$queryRaw<RawInterviewRow[]>`
+    SELECT
+      i."id",
+      i."startTime",
+      i."finishTime",
+      i."exportTime",
+      i."lastUpdated",
+      i."currentStep",
+      i."protocolId",
+      i."isSynthetic",
+      par."identifier" AS "participantIdentifier",
+      p."name" AS "protocolName",
+      COALESCE(jsonb_array_length(p."stages"::jsonb), 0)::int AS "stageCount",
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+          'type', node_type,
+          'count', cnt,
+          'name', COALESCE(p."codebook"->'node'->node_type->>'name', 'Unknown'),
+          'color', p."codebook"->'node'->node_type->>'color'
+        ))
+        FROM (
+          SELECT n->>'type' AS node_type, COUNT(*)::int AS cnt
+          FROM jsonb_array_elements(COALESCE(i."network"->'nodes', '[]'::jsonb)) AS n
+          GROUP BY n->>'type'
+        ) node_counts),
+        '[]'::jsonb
+      ) AS "nodeSummary",
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+          'type', edge_type,
+          'count', cnt,
+          'name', COALESCE(p."codebook"->'edge'->edge_type->>'name', 'Unknown'),
+          'color', p."codebook"->'edge'->edge_type->>'color'
+        ))
+        FROM (
+          SELECT e->>'type' AS edge_type, COUNT(*)::int AS cnt
+          FROM jsonb_array_elements(COALESCE(i."network"->'edges', '[]'::jsonb)) AS e
+          GROUP BY e->>'type'
+        ) edge_counts),
+        '[]'::jsonb
+      ) AS "edgeSummary"
+    FROM "Interview" i
+    JOIN "Protocol" p ON i."protocolId" = p."id"
+    JOIN "Participant" par ON i."participantId" = par."id"
+    ORDER BY i."lastUpdated" DESC
+  `;
 
-  const countByType = (
-    items: unknown[],
-    entityType: 'node' | 'edge',
-  ): NetworkSummaryEntry[] => {
-    const counts = new Map<string, number>();
-    for (const item of items) {
-      if (item === null || typeof item !== 'object') continue;
-      const type =
-        'type' in item && typeof item.type === 'string' ? item.type : 'unknown';
-      counts.set(type, (counts.get(type) ?? 0) + 1);
-    }
-    return [...counts.entries()].map(([type, count]) => {
-      const info = codebook?.[entityType]?.[type];
-      return {
-        type,
-        count,
-        name: info?.name ?? 'Unknown',
-        color: info?.color,
-      };
-    });
-  };
-
-  return {
-    nodes: countByType(nodes, 'node'),
-    edges: countByType(edges, 'edge'),
-  };
-}
-
-async function prisma_getInterviews() {
-  const interviews = await prisma.interview.findMany({
-    select: {
-      id: true,
-      startTime: true,
-      finishTime: true,
-      exportTime: true,
-      lastUpdated: true,
-      currentStep: true,
-      protocolId: true,
-      network: true,
-      isSynthetic: true,
-      participant: {
-        select: {
-          identifier: true,
-        },
-      },
-      protocol: {
-        select: {
-          name: true,
-          stages: true,
-          codebook: true,
-        },
-      },
+  return rows.map((row) => ({
+    id: row.id,
+    startTime: row.startTime,
+    finishTime: row.finishTime,
+    exportTime: row.exportTime,
+    lastUpdated: row.lastUpdated,
+    currentStep: row.currentStep,
+    protocolId: row.protocolId,
+    isSynthetic: row.isSynthetic,
+    participant: { identifier: row.participantIdentifier },
+    protocol: { name: row.protocolName, stageCount: row.stageCount },
+    network: {
+      nodes: row.nodeSummary,
+      edges: row.edgeSummary,
     },
-  });
-
-  return interviews.map(({ network, protocol, ...interview }) => {
-    const stages = Array.isArray(protocol.stages) ? protocol.stages : [];
-    return {
-      ...interview,
-      network: summarizeNetwork(
-        network as Record<string, unknown> | null,
-        protocol.codebook as CodebookLike | null,
-      ),
-      protocol: {
-        name: protocol.name,
-        stageCount: stages.length,
-      },
-    };
-  });
+  }));
 }
 
-export type GetInterviewsQuery = Awaited<
-  ReturnType<typeof prisma_getInterviews>
->;
+export type GetInterviewsQuery = InterviewListRow[];
 
 export async function getInterviews() {
   'use cache';

--- a/queries/interviews.ts
+++ b/queries/interviews.ts
@@ -11,6 +11,8 @@ import { prisma } from '~/lib/db';
 type NetworkSummaryEntry = {
   type: string;
   count: number;
+  name: string;
+  color?: string;
 };
 
 type InterviewNetworkSummary = {
@@ -18,15 +20,24 @@ type InterviewNetworkSummary = {
   edges: NetworkSummaryEntry[];
 };
 
+type CodebookLike = Record<
+  string,
+  Record<string, { name?: string; color?: string }> | undefined
+>;
+
 function summarizeNetwork(
   network: Record<string, unknown> | null,
+  codebook: CodebookLike | null,
 ): InterviewNetworkSummary {
   if (!network) return { nodes: [], edges: [] };
 
   const nodes = Array.isArray(network.nodes) ? network.nodes : [];
   const edges = Array.isArray(network.edges) ? network.edges : [];
 
-  const countByType = (items: unknown[]): NetworkSummaryEntry[] => {
+  const countByType = (
+    items: unknown[],
+    entityType: 'node' | 'edge',
+  ): NetworkSummaryEntry[] => {
     const counts = new Map<string, number>();
     for (const item of items) {
       if (item === null || typeof item !== 'object') continue;
@@ -34,12 +45,20 @@ function summarizeNetwork(
         'type' in item && typeof item.type === 'string' ? item.type : 'unknown';
       counts.set(type, (counts.get(type) ?? 0) + 1);
     }
-    return [...counts.entries()].map(([type, count]) => ({ type, count }));
+    return [...counts.entries()].map(([type, count]) => {
+      const info = codebook?.[entityType]?.[type];
+      return {
+        type,
+        count,
+        name: info?.name ?? 'Unknown',
+        color: info?.color,
+      };
+    });
   };
 
   return {
-    nodes: countByType(nodes),
-    edges: countByType(edges),
+    nodes: countByType(nodes, 'node'),
+    edges: countByType(edges, 'edge'),
   };
 }
 
@@ -70,12 +89,20 @@ async function prisma_getInterviews() {
     },
   });
 
-  return interviews.map((interview) => ({
-    ...interview,
-    network: summarizeNetwork(
-      interview.network as Record<string, unknown> | null,
-    ),
-  }));
+  return interviews.map(({ network, protocol, ...interview }) => {
+    const stages = Array.isArray(protocol.stages) ? protocol.stages : [];
+    return {
+      ...interview,
+      network: summarizeNetwork(
+        network as Record<string, unknown> | null,
+        protocol.codebook as CodebookLike | null,
+      ),
+      protocol: {
+        name: protocol.name,
+        stageCount: stages.length,
+      },
+    };
+  });
 }
 
 export type GetInterviewsQuery = Awaited<

--- a/schemas/export.ts
+++ b/schemas/export.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod/mini';
+import { ExportOptionsSchema } from '~/lib/network-exporters/utils/types';
+
+export const exportInterviewsSchema = z.object({
+  interviewIds: z.array(z.string()).check(z.minLength(1)),
+  exportOptions: ExportOptionsSchema,
+});
+
+export type ExportInterviewsInput = z.infer<typeof exportInterviewsSchema>;

--- a/schemas/export.ts
+++ b/schemas/export.ts
@@ -6,4 +6,4 @@ export const exportInterviewsSchema = z.object({
   exportOptions: ExportOptionsSchema,
 });
 
-export type ExportInterviewsInput = z.infer<typeof exportInterviewsSchema>;
+type ExportInterviewsInput = z.infer<typeof exportInterviewsSchema>;

--- a/schemas/export.ts
+++ b/schemas/export.ts
@@ -5,5 +5,3 @@ export const exportInterviewsSchema = z.object({
   interviewIds: z.array(z.string()).check(z.minLength(1)),
   exportOptions: ExportOptionsSchema,
 });
-
-type ExportInterviewsInput = z.infer<typeof exportInterviewsSchema>;


### PR DESCRIPTION
## Summary

- Replace the blocking export server action with an SSE route handler that streams progress events via Effect Queue/Stream
- Add a persistent toast notification that shows pipeline stages (fetching, formatting, generating files with per-file progress bar, archiving, uploading), with cancel support
- Introduce `ExportProgressProvider` context in the dashboard layout so exports run in the background — users can navigate freely while exporting
- Support concurrent exports (each gets its own toast and SSE connection)
- Add `loading` variant to the toast system with spinner icon and cancel button

## Technical Details

- `generateOutputFiles` converted to an Effect-returning function using `Effect.forEach` with unbounded concurrency and `Ref`-based progress tracking
- Export pipeline accepts an `Effect.Queue` and emits stage/progress events between steps
- SSE stream modeled as `Queue → Stream.fromQueue → Stream.map (SSE format) → Stream.toReadableStream → Response`
- Toast lifecycle: persistent loading → success (auto-dismiss 5s) / error (stays until dismissed)
- Closing toast or clicking Cancel aborts the export via `AbortController`

## Test Plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Unit tests pass (`pnpm test`) — 1842 passing
- [x] Manual: trigger export from interviews page, verify progress toast appears and updates through stages
- [x] Manual: verify zip downloads automatically on completion
- [x] Manual: verify Cancel button and toast close both abort the export
- [x] Manual: verify concurrent exports show separate progress toasts
- [x] Manual: verify error state displays correctly if export fails
- [x] Storybook: verify Loading toast story at Components → Toast → Loading