### PR TITLE
feat: add column-level filtering to DataTable

### DIFF
--- a/app/dashboard/_components/InterviewsTable/Columns.tsx
+++ b/app/dashboard/_components/InterviewsTable/Columns.tsx
@@ -1,9 +1,18 @@
 'use client';
 
 import type { Codebook, NcNetwork, Stage } from '@codaco/shared-consts';
-import { type ColumnDef } from '@tanstack/react-table';
+import { type ColumnDef, type FilterFn } from '@tanstack/react-table';
 import Image from 'next/image';
 import { DataTableColumnHeader } from '~/components/DataTable/ColumnHeader';
+import { FilterableColumnHeader } from '~/components/DataTable/filters/FilterableColumnHeader';
+import {
+  booleanFilterFn,
+  dateFilterFn,
+  facetedFilterFn,
+  operatorFilterFn,
+  rangeFilterFn,
+} from '~/components/DataTable/filters/filterFns';
+import { type Option } from '~/components/DataTable/filters/types';
 import { Badge } from '~/components/ui/badge';
 import { Checkbox } from '~/components/ui/checkbox';
 import { Progress } from '~/components/ui/progress';
@@ -11,9 +20,9 @@ import TimeAgo from '~/components/ui/TimeAgo';
 import type { GetInterviewsReturnType } from '~/queries/interviews';
 import NetworkSummary from './NetworkSummary';
 
-export const InterviewColumns = (): ColumnDef<
-  Awaited<GetInterviewsReturnType>[0]
->[] => [
+type InterviewRow = Awaited<GetInterviewsReturnType>[0];
+
+export const InterviewColumns = (): ColumnDef<InterviewRow>[] => [
   {
     id: 'select',
     header: ({ table }) => (
@@ -71,20 +80,37 @@ export const InterviewColumns = (): ColumnDef<
   {
     id: 'protocolName',
     accessorKey: 'protocol.name',
-    header: ({ column }) => {
-      return (
-        <div className="flex items-center gap-2">
-          <Image
-            src="/images/protocol-icon.png"
-            alt="Protocol icon"
-            className="max-w-none"
-            width={24}
-            height={24}
-          />
-          <DataTableColumnHeader column={column} title="Protocol Name" />
-        </div>
-      );
+    meta: {
+      filterType: 'faceted' as const,
+      filterConfig: {
+        type: 'faceted' as const,
+        options: (data: unknown[]) => {
+          const rows = data as Awaited<GetInterviewsReturnType>;
+          const names = [...new Set(rows.map((r) => r.protocol.name))];
+          return names.map((name) => ({
+            label: name.replace(/\.netcanvas$/, ''),
+            value: name,
+          }));
+        },
+      },
     },
+    filterFn: facetedFilterFn,
+    header: ({ column, table }) => (
+      <div className="flex items-center gap-2">
+        <Image
+          src="/images/protocol-icon.png"
+          alt="Protocol icon"
+          className="max-w-none"
+          width={24}
+          height={24}
+        />
+        <FilterableColumnHeader
+          column={column}
+          table={table}
+          title="Protocol Name"
+        />
+      </div>
+    ),
     cell: ({ row }) => {
       const protocolFileName = row.original.protocol.name;
       const protocolName = protocolFileName.replace(/\.netcanvas$/, '');
@@ -101,9 +127,14 @@ export const InterviewColumns = (): ColumnDef<
   {
     id: 'startTime',
     accessorKey: 'startTime',
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Started" />;
+    meta: {
+      filterType: 'date' as const,
+      filterConfig: { type: 'date' as const },
     },
+    filterFn: dateFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Started" />
+    ),
     cell: ({ row }) => {
       const date = new Date(row.original.startTime);
       return <TimeAgo date={date} className="text-xs" />;
@@ -112,9 +143,14 @@ export const InterviewColumns = (): ColumnDef<
   {
     id: 'lastUpdated',
     accessorKey: 'lastUpdated',
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Updated" />;
+    meta: {
+      filterType: 'date' as const,
+      filterConfig: { type: 'date' as const },
     },
+    filterFn: dateFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Updated" />
+    ),
     cell: ({ row }) => {
       const date = new Date(row.original.lastUpdated);
       return <TimeAgo date={date} className="text-xs" />;
@@ -128,9 +164,25 @@ export const InterviewColumns = (): ColumnDef<
         ? (row.currentStep / stages.length) * 100
         : 0;
     },
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Progress" />;
+    meta: {
+      filterType: 'range' as const,
+      filterConfig: {
+        type: 'range' as const,
+        min: 0,
+        max: 100,
+        step: 1,
+        presets: [
+          { label: 'Not Started', min: 0, max: 0 },
+          { label: 'In Progress', min: 1, max: 99 },
+          { label: 'Complete', min: 100, max: 100 },
+        ],
+        formatLabel: (v: number) => `${String(v)}%`,
+      },
     },
+    filterFn: rangeFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Progress" />
+    ),
     cell: ({ row }) => {
       const stages = row.original.protocol.stages! as unknown as Stage[];
       const progress = (row.original.currentStep / stages.length) * 100;
@@ -150,9 +202,48 @@ export const InterviewColumns = (): ColumnDef<
       const edgeCount = network?.edges?.length ?? 0;
       return nodeCount + edgeCount;
     },
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Network" />;
+    meta: {
+      filterType: 'operator' as const,
+      filterConfig: {
+        type: 'operator' as const,
+        operators: ['eq', 'gt', 'lt', 'gte', 'lte'] as const,
+        entitySelector: {
+          label: 'Entity Type',
+          getOptions: (data: unknown[]) => {
+            const rows = data as Awaited<GetInterviewsReturnType>;
+            const types = new Map<string, Option>();
+            for (const row of rows) {
+              const network = row.network as NcNetwork;
+              const codebook = row.protocol.codebook as Codebook;
+              if (!network || !codebook) continue;
+              for (const node of network.nodes ?? []) {
+                const nodeInfo = codebook.node?.[node.type];
+                if (nodeInfo) {
+                  types.set(`nodes.${node.type}`, {
+                    label: `${nodeInfo.name} (nodes)`,
+                    value: `nodes.${node.type}`,
+                  });
+                }
+              }
+              for (const edge of network.edges ?? []) {
+                const edgeInfo = codebook.edge?.[edge.type];
+                if (edgeInfo) {
+                  types.set(`edges.${edge.type}`, {
+                    label: `${edgeInfo.name} (edges)`,
+                    value: `edges.${edge.type}`,
+                  });
+                }
+              }
+            }
+            return Array.from(types.values());
+          },
+        },
+      },
     },
+    filterFn: operatorFilterFn as FilterFn<InterviewRow>,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Network" />
+    ),
     cell: ({ row }) => {
       const network = row.original.network as NcNetwork;
       const codebook = row.original.protocol.codebook as Codebook;
@@ -161,10 +252,24 @@ export const InterviewColumns = (): ColumnDef<
     },
   },
   {
+    id: 'exportTime',
     accessorKey: 'exportTime',
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Export Status" />;
+    meta: {
+      filterType: 'boolean' as const,
+      filterConfig: {
+        type: 'boolean' as const,
+        trueLabel: 'Exported',
+        falseLabel: 'Not Exported',
+      },
     },
+    filterFn: booleanFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader
+        column={column}
+        table={table}
+        title="Export Status"
+      />
+    ),
     cell: ({ row }) => {
       if (!row.original.exportTime) {
         return <Badge variant="secondary">Not exported</Badge>;

--- a/app/dashboard/_components/InterviewsTable/InterviewsTable.tsx
+++ b/app/dashboard/_components/InterviewsTable/InterviewsTable.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { HardDriveUpload } from 'lucide-react';
+import { flexRender, type Row } from '@tanstack/react-table';
+import type { Interview } from '~/lib/db/generated/client';
+import { FileUp, HardDriveUpload, Loader } from 'lucide-react';
 import { hash as objectHash } from 'ohash';
-import { use, useMemo, useState } from 'react';
+import { use, useCallback, useMemo, useState } from 'react';
 import { ActionsDropdown } from '~/app/dashboard/_components/InterviewsTable/ActionsDropdown';
 import { InterviewColumns } from '~/app/dashboard/_components/InterviewsTable/Columns';
 import { DeleteInterviewsDialog } from '~/app/dashboard/interviews/_components/DeleteInterviewsDialog';
 import { ExportInterviewsDialog } from '~/app/dashboard/interviews/_components/ExportInterviewsDialog';
 import { GenerateInterviewURLs } from '~/app/dashboard/interviews/_components/GenerateInterviewURLs';
-import { DataTable } from '~/components/DataTable/DataTable';
+import { ActiveFilterChips } from '~/components/DataTable/filters/ActiveFilterChips';
 import { Button } from '~/components/ui/Button';
 import {
   DropdownMenu,
@@ -16,8 +18,20 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu';
+import { Input } from '~/components/ui/Input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import { useClientDataTable } from '~/hooks/useClientDataTable';
 import type { GetInterviewsReturnType } from '~/queries/interviews';
 import type { GetProtocolsReturnType } from '~/queries/protocols';
+
+type InterviewRow = Awaited<GetInterviewsReturnType>[0];
 
 export const InterviewsTable = ({
   interviewsPromise,
@@ -32,6 +46,30 @@ export const InterviewsTable = ({
     useState<typeof interviews>();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const columns = useMemo(() => {
+    const base = InterviewColumns();
+
+    const actionsColumn = {
+      id: 'actions',
+      header: () => null,
+      // InterviewRow is a superset of Interview (adds participant/protocol
+      // relations). TanStack's Row generic is invariant, requiring this cast.
+      cell: ({ row }: { row: Row<InterviewRow> }) => (
+        <ActionsDropdown row={row as unknown as Row<Interview>} />
+      ),
+    };
+
+    return [...base, actionsColumn];
+  }, []);
+
+  const { table } = useClientDataTable({
+    data: interviews,
+    columns,
+    enableUrlFilters: true,
+    defaultSortBy: { id: 'lastUpdated', desc: true },
+  });
 
   const unexportedInterviews = useMemo(
     () => interviews.filter((interview) => !interview.exportTime),
@@ -68,6 +106,25 @@ export const InterviewsTable = ({
     setShowExportModal(false);
   };
 
+  const deleteSelectedHandler = () => {
+    setIsDeleting(true);
+    const selectedData = table
+      .getSelectedRowModel()
+      .rows.map((r) => r.original);
+    handleDelete(selectedData);
+    setIsDeleting(false);
+  };
+
+  const exportHandler = useCallback(() => {
+    const selectedData = table
+      .getSelectedRowModel()
+      .rows.map((r) => r.original);
+    setSelectedInterviews(selectedData);
+    setShowExportModal(true);
+  }, [table]);
+
+  const hasSelectedRows = table.getSelectedRowModel().rows.length > 0;
+
   return (
     <>
       <ExportInterviewsDialog
@@ -81,51 +138,154 @@ export const InterviewsTable = ({
         setOpen={setShowDeleteModal}
         interviewsToDelete={selectedInterviews ?? []}
       />
-      <DataTable
-        columns={InterviewColumns()}
-        data={interviews}
-        filterColumnAccessorKey="identifier"
-        handleDeleteSelected={handleDelete}
-        handleExportSelected={(selected) => {
-          setSelectedInterviews(selected);
-          setShowExportModal(true);
-        }}
-        actions={ActionsDropdown}
-        defaultSortBy={{ id: 'lastUpdated', desc: true }}
-        headerItems={
-          <>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button disabled={interviews.length === 0}>
-                  <HardDriveUpload className="mr-2 inline-block h-4 w-4" />
-                  Export Interview Data
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem onClick={handleExportAll}>
-                  Export all interviews
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={completedInterviews.length === 0}
-                  onClick={handleExportCompleted}
+      <div className="flex items-center gap-2 pt-1 pb-4">
+        <Input
+          name="filter"
+          placeholder="Filter by identifier..."
+          value={
+            (table.getColumn('identifier')?.getFilterValue() as string) ?? ''
+          }
+          onChange={(event) =>
+            table.getColumn('identifier')?.setFilterValue(event.target.value)
+          }
+          className="mt-0"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button disabled={interviews.length === 0}>
+              <HardDriveUpload className="mr-2 inline-block h-4 w-4" />
+              Export Interview Data
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onClick={handleExportAll}>
+              Export all interviews
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={completedInterviews.length === 0}
+              onClick={handleExportCompleted}
+            >
+              Export all completed interviews
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={unexportedInterviews.length === 0}
+              onClick={handleExportUnexported}
+            >
+              Export all unexported interviews
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <GenerateInterviewURLs
+          interviews={interviews}
+          protocolsPromise={protocolsPromise}
+        />
+      </div>
+      <ActiveFilterChips table={table} />
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && 'selected'}
                 >
-                  Export all completed interviews
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={unexportedInterviews.length === 0}
-                  onClick={handleExportUnexported}
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
                 >
-                  Export all unexported interviews
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <GenerateInterviewURLs
-              interviews={interviews}
-              protocolsPromise={protocolsPromise}
-            />
-          </>
-        }
-      />
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div>
+        <div className="flex justify-between py-4">
+          <div className="text-muted-foreground text-sm">
+            {table.getFilteredSelectedRowModel().rows.length} of{' '}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
+          </div>
+          <div className="space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+        {hasSelectedRows && (
+          <Button
+            onClick={() => void deleteSelectedHandler()}
+            variant="destructive"
+            size="sm"
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <span className="flex items-center gap-2">
+                Deleting...
+                <Loader className="h-4 w-4 animate-spin text-white" />
+              </span>
+            ) : (
+              'Delete Selected'
+            )}
+          </Button>
+        )}
+
+        {hasSelectedRows && (
+          <Button
+            onClick={exportHandler}
+            variant="default"
+            size="sm"
+            className="mx-2 gap-x-2.5"
+          >
+            Export Selected
+            <FileUp className="h-5 w-5" />
+          </Button>
+        )}
+      </div>
     </>
   );
 };

--- a/components/DataTable/filters/ActiveFilterChips.tsx
+++ b/components/DataTable/filters/ActiveFilterChips.tsx
@@ -1,0 +1,121 @@
+'use no memo';
+'use client';
+
+import { type Table } from '@tanstack/react-table';
+import { X } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { Button } from '~/components/ui/Button';
+import { generateChipLabel } from '~/components/DataTable/filters/chipLabels';
+import type { OperatorFilterValue } from '~/components/DataTable/filters/types';
+
+const chipVariants = {
+  initial: { opacity: 0, scale: 0.8 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.8 },
+};
+
+function getColumnTitle<TData>(
+  column: ReturnType<Table<TData>['getColumn']>,
+  columnId: string,
+): string {
+  const header = column?.columnDef.header;
+  if (typeof header === 'string') return header;
+  return columnId;
+}
+
+type ActiveFilterChipsProps<TData> = {
+  table: Table<TData>;
+};
+
+export function ActiveFilterChips<TData>({
+  table,
+}: ActiveFilterChipsProps<TData>) {
+  const columnFilters = table.getState().columnFilters;
+
+  if (columnFilters.length === 0) return null;
+
+  const chips: {
+    key: string;
+    label: string;
+    onRemove: () => void;
+  }[] = [];
+
+  for (const filter of columnFilters) {
+    const column = table.getColumn(filter.id);
+    if (!column) continue;
+
+    const config = column.columnDef.meta?.filterConfig;
+    if (!config) continue;
+
+    const title = getColumnTitle(column, filter.id);
+    const label = generateChipLabel(title, config, filter.value);
+
+    if (Array.isArray(label)) {
+      label.forEach((text, index) => {
+        chips.push({
+          key: `${filter.id}-${String(index)}`,
+          label: text,
+          onRemove: () => {
+            const currentValue = column.getFilterValue() as
+              | OperatorFilterValue
+              | undefined;
+            if (!currentValue) return;
+            const updated = currentValue.conditions.filter(
+              (_, i) => i !== index,
+            );
+            if (updated.length === 0) {
+              column.setFilterValue(undefined);
+            } else {
+              column.setFilterValue({ conditions: updated });
+            }
+          },
+        });
+      });
+    } else {
+      chips.push({
+        key: filter.id,
+        label,
+        onRemove: () => column.setFilterValue(undefined),
+      });
+    }
+  }
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <AnimatePresence mode="popLayout">
+        {chips.map((chip) => (
+          <motion.span
+            key={chip.key}
+            layout
+            variants={chipVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={{ duration: 0.15 }}
+            className="bg-secondary text-secondary-foreground inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm"
+          >
+            {chip.label}
+            <button
+              type="button"
+              onClick={chip.onRemove}
+              className="hover:bg-secondary-foreground/10 ml-0.5 rounded-full p-0.5 transition-colors"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </motion.span>
+        ))}
+      </AnimatePresence>
+      {chips.length > 1 && (
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => table.resetColumnFilters()}
+        >
+          Clear all
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/components/DataTable/filters/BooleanFilter.tsx
+++ b/components/DataTable/filters/BooleanFilter.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { type BooleanFilterConfig } from '~/components/DataTable/filters/types';
+import { cn } from '~/utils/shadcn';
+
+type BooleanFilterProps = {
+  value: boolean | undefined;
+  onChange: (value: boolean | undefined) => void;
+  config: BooleanFilterConfig;
+};
+
+export function BooleanFilter({ value, onChange, config }: BooleanFilterProps) {
+  const handleClick = (selected: boolean) => {
+    onChange(value === selected ? undefined : selected);
+  };
+
+  return (
+    <div className="flex rounded-lg border">
+      <button
+        type="button"
+        className={cn(
+          'flex-1 rounded-l-lg px-4 py-2 text-sm transition-colors',
+          value === true
+            ? 'bg-primary/10 text-primary font-semibold'
+            : 'text-muted-foreground hover:bg-muted',
+        )}
+        onClick={() => handleClick(true)}
+      >
+        {config.trueLabel}
+      </button>
+      <button
+        type="button"
+        className={cn(
+          'flex-1 rounded-r-lg px-4 py-2 text-sm transition-colors',
+          value === false
+            ? 'bg-primary/10 text-primary font-semibold'
+            : 'text-muted-foreground hover:bg-muted',
+        )}
+        onClick={() => handleClick(false)}
+      >
+        {config.falseLabel}
+      </button>
+    </div>
+  );
+}

--- a/components/DataTable/filters/DateFilter.tsx
+++ b/components/DataTable/filters/DateFilter.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import {
+  type DateFilterConfig,
+  type DateFilterValue,
+} from '~/components/DataTable/filters/types';
+import { cn } from '~/utils/shadcn';
+
+type DateFilterProps = {
+  value: DateFilterValue | undefined;
+  onChange: (value: DateFilterValue | undefined) => void;
+  config: DateFilterConfig;
+};
+
+const RELATIVE_PRESETS = [
+  { label: 'Today', days: 0 },
+  { label: 'Last 7 days', days: 7 },
+  { label: 'Last 30 days', days: 30 },
+  { label: 'Last 90 days', days: 90 },
+] as const;
+
+function computePresetRange(days: number): DateFilterValue {
+  const now = DateTime.now();
+  const to = now.endOf('day').toFormat('yyyy-MM-dd');
+  const from =
+    days === 0
+      ? now.startOf('day').toFormat('yyyy-MM-dd')
+      : now.minus({ days }).startOf('day').toFormat('yyyy-MM-dd');
+  return { from, to };
+}
+
+export function DateFilter({
+  value,
+  onChange,
+  config: _config,
+}: DateFilterProps) {
+  const activePreset = useMemo(() => {
+    if (!value) return null;
+    return (
+      RELATIVE_PRESETS.find((preset) => {
+        const range = computePresetRange(preset.days);
+        return range.from === value.from && range.to === value.to;
+      })?.label ?? null
+    );
+  }, [value]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        {RELATIVE_PRESETS.map((preset) => (
+          <button
+            key={preset.label}
+            type="button"
+            className={cn(
+              'rounded-full border px-3 py-1 text-xs transition-colors',
+              activePreset === preset.label
+                ? 'bg-primary/10 text-primary font-semibold'
+                : 'text-muted-foreground hover:bg-muted',
+            )}
+            onClick={() => onChange(computePresetRange(preset.days))}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="flex flex-1 flex-col gap-1">
+          <label className="text-muted-foreground text-xs">From</label>
+          <input
+            type="date"
+            value={value?.from ?? ''}
+            onChange={(e) => {
+              const from = e.target.value;
+              if (from) {
+                onChange({ from, to: value?.to ?? from });
+              }
+            }}
+            className="bg-background rounded-md border px-2 py-1 text-sm"
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <label className="text-muted-foreground text-xs">To</label>
+          <input
+            type="date"
+            value={value?.to ?? ''}
+            onChange={(e) => {
+              const to = e.target.value;
+              if (to) {
+                onChange({ from: value?.from ?? to, to });
+              }
+            }}
+            className="bg-background rounded-md border px-2 py-1 text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DataTable/filters/FacetedFilter.tsx
+++ b/components/DataTable/filters/FacetedFilter.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import {
+  type FacetedFilterConfig,
+  type Option,
+} from '~/components/DataTable/filters/types';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '~/components/ui/command';
+import { cn } from '~/utils/shadcn';
+
+type FacetedFilterProps = {
+  value: string[] | undefined;
+  onChange: (value: string[] | undefined) => void;
+  config: FacetedFilterConfig;
+  data: unknown[];
+};
+
+export function FacetedFilter({
+  value,
+  onChange,
+  config,
+  data,
+}: FacetedFilterProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [inputValue, setInputValue] = useState('');
+
+  const options: Option[] = useMemo(
+    () =>
+      typeof config.options === 'function'
+        ? config.options(data)
+        : config.options,
+    [config, data],
+  );
+
+  const selectedValues = useMemo(() => new Set(value ?? []), [value]);
+
+  const toggleOption = (optionValue: string) => {
+    const next = new Set(selectedValues);
+    if (next.has(optionValue)) {
+      next.delete(optionValue);
+    } else {
+      next.add(optionValue);
+    }
+    const arr = Array.from(next);
+    onChange(arr.length > 0 ? arr : undefined);
+    inputRef.current?.focus();
+  };
+
+  const selectAll = () => {
+    onChange(options.map((o) => o.value));
+  };
+
+  const deselectAll = () => {
+    onChange(undefined);
+  };
+
+  return (
+    <Command loop>
+      <CommandInput
+        name="filter"
+        ref={inputRef}
+        placeholder="Search..."
+        value={inputValue}
+        onValueChange={setInputValue}
+        className="my-2 h-8"
+      />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup className="max-h-72 overflow-auto">
+          <CommandItem onSelect={selectAll}>Select All</CommandItem>
+          <CommandItem onSelect={deselectAll}>Deselect All</CommandItem>
+          <CommandSeparator />
+          {options.map((option) => {
+            const isSelected = selectedValues.has(option.value);
+            return (
+              <CommandItem
+                key={option.value}
+                value={option.value}
+                onSelect={() => toggleOption(option.value)}
+              >
+                <Check
+                  className={cn(
+                    'mr-2 h-4 w-4',
+                    isSelected ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+                <span>{option.label}</span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/components/DataTable/filters/FilterableColumnHeader.tsx
+++ b/components/DataTable/filters/FilterableColumnHeader.tsx
@@ -1,0 +1,197 @@
+'use no memo';
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+import { type Column, type Table } from '@tanstack/react-table';
+import { ArrowDown, ArrowUp, ArrowUpDown, Filter } from 'lucide-react';
+import { Button, buttonVariants } from '~/components/ui/Button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '~/components/ui/popover';
+import { BooleanFilter } from '~/components/DataTable/filters/BooleanFilter';
+import { DateFilter } from '~/components/DataTable/filters/DateFilter';
+import { FacetedFilter } from '~/components/DataTable/filters/FacetedFilter';
+import { OperatorFilter } from '~/components/DataTable/filters/OperatorFilter';
+import { RangeFilter } from '~/components/DataTable/filters/RangeFilter';
+import {
+  type BooleanFilterValue,
+  type DateFilterValue,
+  type FacetedFilterValue,
+  type FilterConfig,
+  type FilterValue,
+  type OperatorFilterValue,
+  type RangeFilterValue,
+} from '~/components/DataTable/filters/types';
+import { cn } from '~/utils/shadcn';
+
+type FilterableColumnHeaderProps<TData, TValue> = {
+  column: Column<TData, TValue>;
+  title: ReactNode;
+  table: Table<TData>;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>;
+
+function renderFilter(
+  config: FilterConfig,
+  value: FilterValue | undefined,
+  onChange: (value: FilterValue | undefined) => void,
+  data: unknown[],
+) {
+  switch (config.type) {
+    case 'range':
+      return (
+        <RangeFilter
+          value={value as RangeFilterValue | undefined}
+          onChange={onChange as (v: RangeFilterValue | undefined) => void}
+          config={config}
+        />
+      );
+    case 'date':
+      return (
+        <DateFilter
+          value={value as DateFilterValue | undefined}
+          onChange={onChange as (v: DateFilterValue | undefined) => void}
+          config={config}
+        />
+      );
+    case 'boolean':
+      return (
+        <BooleanFilter
+          value={value as BooleanFilterValue | undefined}
+          onChange={onChange as (v: BooleanFilterValue | undefined) => void}
+          config={config}
+        />
+      );
+    case 'faceted':
+      return (
+        <FacetedFilter
+          value={value as FacetedFilterValue | undefined}
+          onChange={onChange as (v: FacetedFilterValue | undefined) => void}
+          config={config}
+          data={data}
+        />
+      );
+    case 'operator':
+      return (
+        <OperatorFilter
+          value={value as OperatorFilterValue | undefined}
+          onChange={onChange as (v: OperatorFilterValue | undefined) => void}
+          config={config}
+          data={data}
+        />
+      );
+  }
+}
+
+export function FilterableColumnHeader<TData, TValue>({
+  column,
+  title,
+  table,
+  className,
+  ...props
+}: FilterableColumnHeaderProps<TData, TValue>) {
+  const [open, setOpen] = useState(false);
+  const [stagedValue, setStagedValue] = useState<FilterValue | undefined>(
+    undefined,
+  );
+
+  const filterType = column.columnDef.meta?.filterType;
+  const filterConfig = column.columnDef.meta?.filterConfig;
+  const isFiltered = column.getIsFiltered();
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        setStagedValue(column.getFilterValue() as FilterValue | undefined);
+      }
+      setOpen(nextOpen);
+    },
+    [column],
+  );
+
+  const handleApply = useCallback(() => {
+    column.setFilterValue(stagedValue);
+    setOpen(false);
+  }, [column, stagedValue]);
+
+  const handleClear = useCallback(() => {
+    column.setFilterValue(undefined);
+    setOpen(false);
+  }, [column]);
+
+  if (!column.getCanSort() && !filterType) {
+    return (
+      <div
+        className={cn(
+          buttonVariants({ size: 'sm', variant: 'tableHeader' }),
+          'pointer-events-none',
+          className,
+        )}
+        {...props}
+      >
+        {title}
+      </div>
+    );
+  }
+
+  const data = table.getCoreRowModel().rows.map((r) => r.original);
+
+  return (
+    <div className={cn('flex items-center', className)} {...props}>
+      {column.getCanSort() ? (
+        <Button
+          variant="tableHeader"
+          size="sm"
+          onClick={() => column.toggleSorting()}
+        >
+          <span>{title}</span>
+          {column.getIsSorted() === 'desc' ? (
+            <ArrowDown className="text-success ml-2 h-4 w-4" />
+          ) : column.getIsSorted() === 'asc' ? (
+            <ArrowUp className="text-success ml-2 h-4 w-4" />
+          ) : (
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          )}
+        </Button>
+      ) : (
+        <span
+          className={cn(
+            buttonVariants({ size: 'sm', variant: 'tableHeader' }),
+            'pointer-events-none',
+          )}
+        >
+          {title}
+        </span>
+      )}
+
+      {filterType && filterConfig && (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="icon" className="relative h-8 w-8">
+              <Filter
+                className={cn('h-3.5 w-3.5', isFiltered && 'text-success')}
+              />
+              {isFiltered && (
+                <span className="bg-success absolute top-1.5 right-1.5 h-2 w-2 rounded-full" />
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80">
+            <div className="space-y-4">
+              {renderFilter(filterConfig, stagedValue, setStagedValue, data)}
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={handleClear}>
+                  Clear
+                </Button>
+                <Button size="sm" onClick={handleApply}>
+                  Apply
+                </Button>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/components/DataTable/filters/OperatorFilter.tsx
+++ b/components/DataTable/filters/OperatorFilter.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import {
+  type OperatorCondition,
+  type OperatorFilterConfig,
+  type OperatorFilterValue,
+  type Option,
+} from '~/components/DataTable/filters/types';
+import { Button } from '~/components/ui/Button';
+import { cn } from '~/utils/shadcn';
+
+type OperatorFilterProps = {
+  value: OperatorFilterValue | undefined;
+  onChange: (value: OperatorFilterValue | undefined) => void;
+  config: OperatorFilterConfig;
+  data: unknown[];
+};
+
+const VALID_OPERATORS: readonly string[] = ['eq', 'gt', 'lt', 'gte', 'lte'];
+
+function isValidOperator(val: string): val is OperatorCondition['operator'] {
+  return VALID_OPERATORS.includes(val);
+}
+
+const OPERATOR_LABELS: Record<OperatorCondition['operator'], string> = {
+  eq: 'equals',
+  gt: 'greater than',
+  lt: 'less than',
+  gte: 'greater than or equal',
+  lte: 'less than or equal',
+};
+
+const OPERATOR_SYMBOLS: Record<OperatorCondition['operator'], string> = {
+  eq: '=',
+  gt: '>',
+  lt: '<',
+  gte: '≥',
+  lte: '≤',
+};
+
+export function OperatorFilter({
+  value,
+  onChange,
+  config,
+  data,
+}: OperatorFilterProps) {
+  const conditions = value?.conditions ?? [];
+
+  const entityOptions: Option[] = useMemo(
+    () => config.entitySelector?.getOptions(data) ?? [],
+    [config.entitySelector, data],
+  );
+
+  const [selectedEntity, setSelectedEntity] = useState<string>(
+    entityOptions[0]?.value ?? '',
+  );
+  const [selectedOperator, setSelectedOperator] = useState<
+    OperatorCondition['operator']
+  >(config.operators[0] ?? 'eq');
+  const [inputValue, setInputValue] = useState<string>('');
+
+  const addCondition = () => {
+    const numValue = Number(inputValue);
+    if (!selectedEntity || inputValue === '' || isNaN(numValue)) return;
+
+    const entityOption = entityOptions.find((o) => o.value === selectedEntity);
+    if (!entityOption) return;
+
+    const newCondition: OperatorCondition = {
+      entityType: selectedEntity,
+      entityKind: 'nodes',
+      operator: selectedOperator,
+      value: numValue,
+    };
+
+    const newConditions = [...conditions, newCondition];
+    onChange({ conditions: newConditions });
+    setInputValue('');
+  };
+
+  const removeCondition = (index: number) => {
+    const newConditions = conditions.filter((_, i) => i !== index);
+    onChange(
+      newConditions.length > 0 ? { conditions: newConditions } : undefined,
+    );
+  };
+
+  const getEntityLabel = (entityType: string) =>
+    entityOptions.find((o) => o.value === entityType)?.label ?? entityType;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {config.entitySelector && entityOptions.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <label className="text-muted-foreground text-xs">
+            {config.entitySelector.label}
+          </label>
+          <div className="flex flex-wrap gap-1">
+            {entityOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={cn(
+                  'rounded-full border px-3 py-1 text-xs transition-colors',
+                  selectedEntity === option.value
+                    ? 'bg-primary/10 text-primary font-semibold'
+                    : 'text-muted-foreground hover:bg-muted',
+                )}
+                onClick={() => setSelectedEntity(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-end gap-2">
+        <div className="flex flex-col gap-1">
+          <label className="text-muted-foreground text-xs">Operator</label>
+          <select
+            value={selectedOperator}
+            onChange={(e) => {
+              if (isValidOperator(e.target.value)) {
+                setSelectedOperator(e.target.value);
+              }
+            }}
+            className="bg-background rounded-md border px-2 py-1 text-sm"
+          >
+            {config.operators.map((op) => (
+              <option key={op} value={op}>
+                {OPERATOR_LABELS[op]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-muted-foreground text-xs">Value</label>
+          <input
+            type="number"
+            min="0"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addCondition();
+              }
+            }}
+            className="bg-background w-20 rounded-md border px-2 py-1 text-sm"
+          />
+        </div>
+
+        <Button size="sm" onClick={addCondition}>
+          Add
+        </Button>
+      </div>
+
+      {conditions.length > 0 && (
+        <div className="flex flex-col gap-1">
+          {conditions.map((condition, index) => (
+            <div
+              key={`${condition.entityType}-${condition.operator}-${condition.value}-${String(index)}`}
+              className="bg-muted/50 flex items-center justify-between rounded-md border px-2 py-1 text-sm"
+            >
+              <span>
+                {getEntityLabel(condition.entityType)}{' '}
+                {OPERATOR_SYMBOLS[condition.operator]} {condition.value}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeCondition(index)}
+                className="text-muted-foreground hover:text-foreground ml-2"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/DataTable/filters/OperatorFilter.tsx
+++ b/components/DataTable/filters/OperatorFilter.tsx
@@ -68,9 +68,17 @@ export function OperatorFilter({
     const entityOption = entityOptions.find((o) => o.value === selectedEntity);
     if (!entityOption) return;
 
+    // Entity value format: "nodes.typeName" or "edges.typeName"
+    const [entityKind, entityType] = selectedEntity.split('.') as [
+      string,
+      string | undefined,
+    ];
+    if (!entityType || (entityKind !== 'nodes' && entityKind !== 'edges'))
+      return;
+
     const newCondition: OperatorCondition = {
-      entityType: selectedEntity,
-      entityKind: 'nodes',
+      entityType,
+      entityKind,
       operator: selectedOperator,
       value: numValue,
     };

--- a/components/DataTable/filters/RangeFilter.tsx
+++ b/components/DataTable/filters/RangeFilter.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import {
+  type RangeFilterConfig,
+  type RangeFilterValue,
+} from '~/components/DataTable/filters/types';
+import { cn } from '~/utils/shadcn';
+
+type RangeFilterProps = {
+  value: RangeFilterValue | undefined;
+  onChange: (value: RangeFilterValue | undefined) => void;
+  config: RangeFilterConfig;
+};
+
+export function RangeFilter({ value, onChange, config }: RangeFilterProps) {
+  const { min: configMin, max: configMax, step = 1, presets } = config;
+  const formatLabel = config.formatLabel ?? String;
+
+  const currentMin = value?.min ?? configMin;
+  const currentMax = value?.max ?? configMax;
+
+  const minPercent = ((currentMin - configMin) / (configMax - configMin)) * 100;
+  const maxPercent = ((currentMax - configMin) / (configMax - configMin)) * 100;
+
+  const activePreset = useMemo(() => {
+    if (!presets || !value) return null;
+    return (
+      presets.find((p) => p.min === value.min && p.max === value.max) ?? null
+    );
+  }, [presets, value]);
+
+  const handleMinChange = useCallback(
+    (newMin: number) => {
+      const clampedMin = Math.min(newMin, currentMax);
+      onChange({ min: clampedMin, max: currentMax });
+    },
+    [currentMax, onChange],
+  );
+
+  const handleMaxChange = useCallback(
+    (newMax: number) => {
+      const clampedMax = Math.max(newMax, currentMin);
+      onChange({ min: currentMin, max: clampedMax });
+    },
+    [currentMin, onChange],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {presets && presets.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {presets.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              className={cn(
+                'rounded-full border px-3 py-1 text-xs transition-colors',
+                activePreset?.label === preset.label
+                  ? 'bg-primary/10 text-primary font-semibold'
+                  : 'text-muted-foreground hover:bg-muted',
+              )}
+              onClick={() => onChange({ min: preset.min, max: preset.max })}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <div className="relative h-6">
+          <div className="bg-muted absolute top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full" />
+          <div
+            className="bg-primary absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full"
+            style={{
+              left: `${minPercent}%`,
+              width: `${maxPercent - minPercent}%`,
+            }}
+          />
+          <input
+            type="range"
+            min={configMin}
+            max={configMax}
+            step={step}
+            value={currentMin}
+            onChange={(e) => handleMinChange(Number(e.target.value))}
+            className="[&::-moz-range-thumb]:border-primary [&::-moz-range-thumb]:bg-background [&::-webkit-slider-thumb]:border-primary [&::-webkit-slider-thumb]:bg-background pointer-events-none absolute top-0 h-full w-full appearance-none bg-transparent [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2"
+          />
+          <input
+            type="range"
+            min={configMin}
+            max={configMax}
+            step={step}
+            value={currentMax}
+            onChange={(e) => handleMaxChange(Number(e.target.value))}
+            className="[&::-moz-range-thumb]:border-primary [&::-moz-range-thumb]:bg-background [&::-webkit-slider-thumb]:border-primary [&::-webkit-slider-thumb]:bg-background pointer-events-none absolute top-0 h-full w-full appearance-none bg-transparent [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2"
+          />
+        </div>
+        <div className="text-muted-foreground flex justify-between text-xs">
+          <span>{formatLabel(currentMin)}</span>
+          <span>{formatLabel(currentMax)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DataTable/filters/__tests__/chipLabels.test.ts
+++ b/components/DataTable/filters/__tests__/chipLabels.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  BooleanFilterConfig,
+  RangeFilterConfig,
+} from '~/components/DataTable/filters/types';
+import { generateChipLabel } from '~/components/DataTable/filters/chipLabels';
+
+describe('generateChipLabel', () => {
+  it('generates range label with formatLabel', () => {
+    const config: RangeFilterConfig = {
+      type: 'range',
+      min: 0,
+      max: 100,
+      formatLabel: (v) => `${v}%`,
+    };
+    expect(generateChipLabel('Progress', config, { min: 25, max: 75 })).toBe(
+      'Progress: 25% \u2013 75%',
+    );
+  });
+
+  it('shows preset label when value matches preset exactly', () => {
+    const config: RangeFilterConfig = {
+      type: 'range',
+      min: 0,
+      max: 100,
+      presets: [{ label: 'Complete', min: 100, max: 100 }],
+    };
+    expect(generateChipLabel('Progress', config, { min: 100, max: 100 })).toBe(
+      'Progress: Complete',
+    );
+  });
+
+  it('generates boolean label for true', () => {
+    const config: BooleanFilterConfig = {
+      type: 'boolean',
+      trueLabel: 'Exported',
+      falseLabel: 'Not Exported',
+    };
+    expect(generateChipLabel('Export Status', config, true)).toBe(
+      'Export Status: Exported',
+    );
+  });
+
+  it('generates boolean label for false', () => {
+    const config: BooleanFilterConfig = {
+      type: 'boolean',
+      trueLabel: 'Exported',
+      falseLabel: 'Not Exported',
+    };
+    expect(generateChipLabel('Export Status', config, false)).toBe(
+      'Export Status: Not Exported',
+    );
+  });
+});

--- a/components/DataTable/filters/__tests__/filterFns.test.ts
+++ b/components/DataTable/filters/__tests__/filterFns.test.ts
@@ -1,0 +1,285 @@
+import { type Row } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+import {
+  booleanFilterFn,
+  dateFilterFn,
+  facetedFilterFn,
+  operatorFilterFn,
+  rangeFilterFn,
+} from '~/components/DataTable/filters/filterFns';
+
+function mockRow<T>(original: T, getValue?: (id: string) => unknown): Row<T> {
+  return {
+    original,
+    getValue: getValue ?? (() => undefined),
+  } as unknown as Row<T>;
+}
+
+describe('rangeFilterFn', () => {
+  it('includes values within range', () => {
+    const row = mockRow({}, () => 50);
+    expect(rangeFilterFn(row, 'progress', { min: 0, max: 100 })).toBe(true);
+  });
+
+  it('includes boundary values', () => {
+    const rowMin = mockRow({}, () => 0);
+    const rowMax = mockRow({}, () => 100);
+    expect(rangeFilterFn(rowMin, 'progress', { min: 0, max: 100 })).toBe(true);
+    expect(rangeFilterFn(rowMax, 'progress', { min: 0, max: 100 })).toBe(true);
+  });
+
+  it('excludes values outside range', () => {
+    const row = mockRow({}, () => 150);
+    expect(rangeFilterFn(row, 'progress', { min: 0, max: 100 })).toBe(false);
+  });
+});
+
+describe('dateFilterFn', () => {
+  it('includes dates within range', () => {
+    const row = mockRow({}, () => new Date('2025-06-15'));
+    expect(
+      dateFilterFn(row, 'createdAt', { from: '2025-06-01', to: '2025-06-30' }),
+    ).toBe(true);
+  });
+
+  it('excludes dates outside range', () => {
+    const row = mockRow({}, () => new Date('2025-07-15'));
+    expect(
+      dateFilterFn(row, 'createdAt', { from: '2025-06-01', to: '2025-06-30' }),
+    ).toBe(false);
+  });
+
+  it('includes boundary dates (inclusive)', () => {
+    const rowFrom = mockRow({}, () => new Date('2025-06-01'));
+    const rowTo = mockRow({}, () => new Date('2025-06-30T23:59:59.999'));
+    expect(
+      dateFilterFn(rowFrom, 'createdAt', {
+        from: '2025-06-01',
+        to: '2025-06-30',
+      }),
+    ).toBe(true);
+    expect(
+      dateFilterFn(rowTo, 'createdAt', {
+        from: '2025-06-01',
+        to: '2025-06-30',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('booleanFilterFn', () => {
+  it('true includes truthy values', () => {
+    const row = mockRow({}, () => new Date());
+    expect(booleanFilterFn(row, 'exportTime', true)).toBe(true);
+  });
+
+  it('true excludes null values', () => {
+    const row = mockRow({}, () => null);
+    expect(booleanFilterFn(row, 'exportTime', true)).toBe(false);
+  });
+
+  it('false includes null values', () => {
+    const row = mockRow({}, () => null);
+    expect(booleanFilterFn(row, 'exportTime', false)).toBe(true);
+  });
+
+  it('false excludes truthy values', () => {
+    const row = mockRow({}, () => new Date());
+    expect(booleanFilterFn(row, 'exportTime', false)).toBe(false);
+  });
+});
+
+describe('facetedFilterFn', () => {
+  it('includes when value is in array', () => {
+    const row = mockRow({}, () => 'active');
+    expect(facetedFilterFn(row, 'status', ['active', 'pending'])).toBe(true);
+  });
+
+  it('excludes when value is not in array', () => {
+    const row = mockRow({}, () => 'archived');
+    expect(facetedFilterFn(row, 'status', ['active', 'pending'])).toBe(false);
+  });
+
+  it('excludes on empty array', () => {
+    const row = mockRow({}, () => 'active');
+    expect(facetedFilterFn(row, 'status', [])).toBe(false);
+  });
+});
+
+type NetworkData = {
+  network: {
+    nodes: { type: string; count: number }[];
+    edges: { type: string; count: number }[];
+  };
+};
+
+describe('operatorFilterFn', () => {
+  const data: NetworkData = {
+    network: {
+      nodes: [
+        { type: 'person', count: 5 },
+        { type: 'place', count: 3 },
+      ],
+      edges: [{ type: 'knows', count: 7 }],
+    },
+  };
+
+  it('gte passes when count meets threshold', () => {
+    const row = mockRow(data);
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gte',
+            value: 5,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('gte fails when count is below threshold', () => {
+    const row = mockRow(data);
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gte',
+            value: 10,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('treats missing entity type as count 0', () => {
+    const row = mockRow(data);
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'unknown',
+            entityKind: 'nodes',
+            operator: 'eq',
+            value: 0,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('multiple AND conditions all must pass', () => {
+    const row = mockRow(data);
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gte',
+            value: 5,
+          },
+          {
+            entityType: 'knows',
+            entityKind: 'edges',
+            operator: 'gt',
+            value: 3,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gte',
+            value: 5,
+          },
+          {
+            entityType: 'knows',
+            entityKind: 'edges',
+            operator: 'gt',
+            value: 10,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('supports all 5 operators', () => {
+    const row = mockRow(data);
+
+    // person count is 5
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'eq',
+            value: 5,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gt',
+            value: 4,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'lt',
+            value: 6,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'gte',
+            value: 5,
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      operatorFilterFn(row, 'network', {
+        conditions: [
+          {
+            entityType: 'person',
+            entityKind: 'nodes',
+            operator: 'lte',
+            value: 5,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/components/DataTable/filters/__tests__/types.test.ts
+++ b/components/DataTable/filters/__tests__/types.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { ColumnFiltersStateSchema } from '~/components/DataTable/filters/types';
+
+describe('ColumnFiltersStateSchema', () => {
+  it('accepts an empty array', () => {
+    expect(ColumnFiltersStateSchema.parse([])).toEqual([]);
+  });
+
+  it('accepts valid range filter', () => {
+    const input = [{ id: 'progress', value: { min: 0, max: 100 } }];
+    expect(ColumnFiltersStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts valid boolean filter', () => {
+    const input = [{ id: 'exportTime', value: true }];
+    expect(ColumnFiltersStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts valid operator filter', () => {
+    const input = [
+      {
+        id: 'network',
+        value: {
+          conditions: [
+            {
+              entityType: 'person',
+              entityKind: 'nodes',
+              operator: 'gte',
+              value: 3,
+            },
+          ],
+        },
+      },
+    ];
+    expect(ColumnFiltersStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts multiple filters', () => {
+    const input = [
+      { id: 'progress', value: { min: 50, max: 100 } },
+      { id: 'exportTime', value: false },
+    ];
+    expect(ColumnFiltersStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => ColumnFiltersStateSchema.parse('invalid')).toThrow();
+  });
+
+  it('rejects entries without id', () => {
+    expect(() => ColumnFiltersStateSchema.parse([{ value: true }])).toThrow();
+  });
+});

--- a/components/DataTable/filters/chipLabels.ts
+++ b/components/DataTable/filters/chipLabels.ts
@@ -1,0 +1,53 @@
+import { DateTime } from 'luxon';
+import type {
+  DateFilterValue,
+  FilterConfig,
+  OperatorFilterValue,
+  RangeFilterValue,
+} from '~/components/DataTable/filters/types';
+
+const OPERATOR_SYMBOLS: Record<string, string> = {
+  eq: '=',
+  gt: '>',
+  lt: '<',
+  gte: '\u2265',
+  lte: '\u2264',
+};
+
+export function generateChipLabel(
+  title: string,
+  config: FilterConfig,
+  value: unknown,
+): string | string[] {
+  switch (config.type) {
+    case 'range': {
+      const v = value as RangeFilterValue;
+      const matchingPreset = config.presets?.find(
+        (p) => p.min === v.min && p.max === v.max,
+      );
+      if (matchingPreset) return `${title}: ${matchingPreset.label}`;
+      const fmt = config.formatLabel ?? String;
+      return `${title}: ${fmt(v.min)} \u2013 ${fmt(v.max)}`;
+    }
+    case 'date': {
+      const v = value as DateFilterValue;
+      const from = DateTime.fromISO(v.from).toLocaleString(DateTime.DATE_MED);
+      const to = DateTime.fromISO(v.to).toLocaleString(DateTime.DATE_MED);
+      return `${title}: ${from} \u2013 ${to}`;
+    }
+    case 'boolean':
+      return `${title}: ${value ? config.trueLabel : config.falseLabel}`;
+    case 'faceted': {
+      const v = value as string[];
+      if (v.length <= 2) return `${title}: ${v.join(', ')}`;
+      return `${title}: ${String(v.length)} selected`;
+    }
+    case 'operator': {
+      const v = value as OperatorFilterValue;
+      return v.conditions.map((c) => {
+        const symbol = OPERATOR_SYMBOLS[c.operator] ?? c.operator;
+        return `${c.entityType} (${c.entityKind}) ${symbol} ${String(c.value)}`;
+      });
+    }
+  }
+}

--- a/components/DataTable/filters/filterFns.ts
+++ b/components/DataTable/filters/filterFns.ts
@@ -1,0 +1,80 @@
+import { type Row } from '@tanstack/react-table';
+import {
+  type DateFilterValue,
+  type OperatorFilterValue,
+  type RangeFilterValue,
+} from '~/components/DataTable/filters/types';
+
+export function rangeFilterFn<TData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: RangeFilterValue,
+): boolean {
+  const value = row.getValue<number>(columnId);
+  return value >= filterValue.min && value <= filterValue.max;
+}
+
+export function dateFilterFn<TData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: DateFilterValue,
+): boolean {
+  const date = row.getValue<Date>(columnId);
+  if (!date) return false;
+  const from = new Date(filterValue.from);
+  const to = new Date(filterValue.to);
+  to.setHours(23, 59, 59, 999);
+  return date >= from && date <= to;
+}
+
+export function booleanFilterFn<TData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: boolean,
+): boolean {
+  const value = row.getValue(columnId);
+  return filterValue ? !!value : !value;
+}
+
+export function facetedFilterFn<TData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: string[],
+): boolean {
+  const value = row.getValue<string>(columnId);
+  return filterValue.includes(value);
+}
+
+export function operatorFilterFn<
+  TData extends {
+    network: {
+      nodes: { type: string; count: number }[];
+      edges: { type: string; count: number }[];
+    };
+  },
+>(
+  row: Row<TData>,
+  _columnId: string,
+  filterValue: OperatorFilterValue,
+): boolean {
+  const network = row.original.network;
+  return filterValue.conditions.every((cond) => {
+    const entries = network[cond.entityKind];
+    const entry = entries.find((e) => e.type === cond.entityType);
+    const count = entry?.count ?? 0;
+    switch (cond.operator) {
+      case 'eq':
+        return count === cond.value;
+      case 'gt':
+        return count > cond.value;
+      case 'lt':
+        return count < cond.value;
+      case 'gte':
+        return count >= cond.value;
+      case 'lte':
+        return count <= cond.value;
+      default:
+        return true;
+    }
+  });
+}

--- a/components/DataTable/filters/types.ts
+++ b/components/DataTable/filters/types.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+export type Option = {
+  label: string;
+  value: string;
+};
+
+export type RangePreset = {
+  label: string;
+  min: number;
+  max: number;
+};
+
+export type RangeFilterConfig = {
+  type: 'range';
+  min: number;
+  max: number;
+  step?: number;
+  presets?: RangePreset[];
+  formatLabel?: (value: number) => string;
+};
+
+export type DateFilterConfig = {
+  type: 'date';
+};
+
+export type BooleanFilterConfig = {
+  type: 'boolean';
+  trueLabel: string;
+  falseLabel: string;
+};
+
+export type FacetedFilterConfig = {
+  type: 'faceted';
+  options: Option[] | ((data: unknown[]) => Option[]);
+};
+
+export type OperatorFilterConfig = {
+  type: 'operator';
+  operators: ('eq' | 'gt' | 'lt' | 'gte' | 'lte')[];
+  entitySelector?: {
+    label: string;
+    getOptions: (data: unknown[]) => Option[];
+  };
+};
+
+export type FilterConfig =
+  | RangeFilterConfig
+  | DateFilterConfig
+  | BooleanFilterConfig
+  | FacetedFilterConfig
+  | OperatorFilterConfig;
+
+export type RangeFilterValue = {
+  min: number;
+  max: number;
+};
+
+export type DateFilterValue = {
+  from: string;
+  to: string;
+};
+
+export type OperatorCondition = {
+  entityType: string;
+  entityKind: 'nodes' | 'edges';
+  operator: 'eq' | 'gt' | 'lt' | 'gte' | 'lte';
+  value: number;
+};
+
+export type OperatorFilterValue = {
+  conditions: OperatorCondition[];
+};
+
+export type FacetedFilterValue = string[];
+export type BooleanFilterValue = boolean;
+
+export type FilterValue =
+  | RangeFilterValue
+  | DateFilterValue
+  | BooleanFilterValue
+  | FacetedFilterValue
+  | OperatorFilterValue;
+
+// z.unknown() is intentional — each filter component validates its own value
+// shape. The schema is deliberately loose at this layer.
+export const ColumnFiltersStateSchema = z.array(
+  z.object({
+    id: z.string(),
+    value: z.unknown(),
+  }),
+);
+
+export type ColumnFiltersStateSchema = z.infer<typeof ColumnFiltersStateSchema>;

--- a/hooks/__tests__/useClientDataTable.test.tsx
+++ b/hooks/__tests__/useClientDataTable.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { type ColumnDef } from '@tanstack/react-table';
+import { describe, expect, it, vi } from 'vitest';
+import { useClientDataTable } from '~/hooks/useClientDataTable';
+
+vi.mock('nuqs', () => ({
+  useQueryState: () => [[], vi.fn()],
+  parseAsJson: () => ({ withDefault: () => ({}) }),
+}));
+
+type TestRow = { id: string; name: string };
+
+const columns: ColumnDef<TestRow>[] = [
+  { accessorKey: 'id' },
+  { accessorKey: 'name' },
+];
+
+const data: TestRow[] = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+];
+
+describe('useClientDataTable', () => {
+  it('initializes with empty column filters by default', () => {
+    const { result } = renderHook(() => useClientDataTable({ data, columns }));
+    expect(result.current.table.getState().columnFilters).toEqual([]);
+  });
+
+  it('applies column filter to reduce visible rows', () => {
+    const { result } = renderHook(() => useClientDataTable({ data, columns }));
+    act(() => {
+      result.current.table.getColumn('name')?.setFilterValue('Alice');
+    });
+    expect(result.current.table.getFilteredRowModel().rows).toHaveLength(1);
+  });
+});

--- a/hooks/useClientDataTable.ts
+++ b/hooks/useClientDataTable.ts
@@ -1,0 +1,89 @@
+'use client';
+
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type OnChangeFn,
+  type Row,
+  type SortingState,
+} from '@tanstack/react-table';
+import { parseAsJson, useQueryState } from 'nuqs';
+import { useState } from 'react';
+import { ColumnFiltersStateSchema } from '~/components/DataTable/filters/types';
+
+type UseClientDataTableOptions<TData, TValue> = {
+  data: TData[];
+  columns: ColumnDef<TData, TValue>[];
+  enablePagination?: boolean;
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
+  defaultSortBy?: { id: string; desc: boolean };
+  enableUrlFilters?: boolean;
+};
+
+export function useClientDataTable<TData, TValue>({
+  data,
+  columns,
+  enablePagination = true,
+  enableRowSelection = true,
+  defaultSortBy,
+  enableUrlFilters,
+}: UseClientDataTableOptions<TData, TValue>) {
+  // TanStack Table returns a mutable ref with stable identity, defeating React Compiler memoization.
+  'use no memo';
+  const [sorting, setSorting] = useState<SortingState>(
+    defaultSortBy ? [{ ...defaultSortBy }] : [],
+  );
+  const [rowSelection, setRowSelection] = useState({});
+
+  // ColumnFiltersStateSchema uses z.unknown() for value, which Zod infers
+  // as optional. The assertion narrows to TanStack's ColumnFiltersState where
+  // value is required — safe because Zod validates the structure.
+  const [urlFilters, setUrlFilters] = useQueryState(
+    'filters',
+    parseAsJson<ColumnFiltersState>(
+      (value) => ColumnFiltersStateSchema.parse(value) as ColumnFiltersState,
+    ).withDefault([]),
+  );
+
+  const [localFilters, setLocalFilters] = useState<ColumnFiltersState>([]);
+
+  const columnFilters = enableUrlFilters ? urlFilters : localFilters;
+
+  const onColumnFiltersChange: OnChangeFn<ColumnFiltersState> = enableUrlFilters
+    ? (updaterOrValue) => {
+        void setUrlFilters((prev) => {
+          const current = prev ?? [];
+          return typeof updaterOrValue === 'function'
+            ? updaterOrValue(current)
+            : updaterOrValue;
+        });
+      }
+    : setLocalFilters;
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    ...(enablePagination && {
+      getPaginationRowModel: getPaginationRowModel(),
+    }),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    onRowSelectionChange: setRowSelection,
+    onColumnFiltersChange,
+    getFilteredRowModel: getFilteredRowModel(),
+    enableRowSelection,
+    state: {
+      sorting,
+      rowSelection,
+      columnFilters,
+    },
+  });
+
+  return { table };
+}

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@types/d3": "^7.4.3",
     "@types/d3-interpolate-path": "^2.0.3",
     "@types/eslint": "^8.56.12",
+    "@types/luxon": "^3.7.1",
     "@types/node": "^22.13.9",
     "@types/papaparse": "^5.5.1",
     "@types/react": "^18.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@types/eslint':
         specifier: ^8.56.12
         version: 8.56.12
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.3
@@ -2921,6 +2924,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -9927,6 +9933,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/luxon@3.7.1': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/stories/DataTable.stories.tsx
+++ b/stories/DataTable.stories.tsx
@@ -1,0 +1,293 @@
+import { flexRender, type ColumnDef } from '@tanstack/react-table';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { ActiveFilterChips } from '~/components/DataTable/filters/ActiveFilterChips';
+import { FilterableColumnHeader } from '~/components/DataTable/filters/FilterableColumnHeader';
+import {
+  booleanFilterFn,
+  dateFilterFn,
+  facetedFilterFn,
+  rangeFilterFn,
+} from '~/components/DataTable/filters/filterFns';
+import { Button } from '~/components/ui/Button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import { useClientDataTable } from '~/hooks/useClientDataTable';
+
+type FilterablePerson = {
+  name: string;
+  role: string;
+  score: number;
+  active: boolean;
+  joinDate: Date;
+};
+
+const roles = ['Engineer', 'Designer', 'Manager', 'QA', 'DevOps'] as const;
+
+const sampleData: FilterablePerson[] = [
+  {
+    name: 'Alice Johnson',
+    role: 'Engineer',
+    score: 92,
+    active: true,
+    joinDate: new Date('2023-01-15'),
+  },
+  {
+    name: 'Bob Smith',
+    role: 'Designer',
+    score: 78,
+    active: true,
+    joinDate: new Date('2023-03-22'),
+  },
+  {
+    name: 'Carol Davis',
+    role: 'Manager',
+    score: 45,
+    active: false,
+    joinDate: new Date('2022-11-10'),
+  },
+  {
+    name: 'Dan Wilson',
+    role: 'QA',
+    score: 88,
+    active: true,
+    joinDate: new Date('2024-02-01'),
+  },
+  {
+    name: 'Eve Martinez',
+    role: 'DevOps',
+    score: 63,
+    active: false,
+    joinDate: new Date('2023-07-18'),
+  },
+  {
+    name: 'Frank Lee',
+    role: 'Engineer',
+    score: 95,
+    active: true,
+    joinDate: new Date('2022-06-05'),
+  },
+  {
+    name: 'Grace Chen',
+    role: 'Designer',
+    score: 30,
+    active: false,
+    joinDate: new Date('2024-05-12'),
+  },
+  {
+    name: 'Henry Kim',
+    role: 'Manager',
+    score: 71,
+    active: true,
+    joinDate: new Date('2023-09-30'),
+  },
+  {
+    name: 'Ivy Patel',
+    role: 'QA',
+    score: 54,
+    active: true,
+    joinDate: new Date('2024-01-08'),
+  },
+  {
+    name: 'Jack Brown',
+    role: 'Engineer',
+    score: 82,
+    active: false,
+    joinDate: new Date('2022-12-20'),
+  },
+  {
+    name: 'Karen White',
+    role: 'DevOps',
+    score: 19,
+    active: true,
+    joinDate: new Date('2023-04-14'),
+  },
+  {
+    name: 'Leo Nguyen',
+    role: 'Designer',
+    score: 67,
+    active: true,
+    joinDate: new Date('2024-03-25'),
+  },
+];
+
+const columns: ColumnDef<FilterablePerson>[] = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Name" />
+    ),
+  },
+  {
+    id: 'role',
+    accessorKey: 'role',
+    meta: {
+      filterType: 'faceted' as const,
+      filterConfig: {
+        type: 'faceted' as const,
+        options: roles.map((r) => ({ label: r, value: r })),
+      },
+    },
+    filterFn: facetedFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Role" />
+    ),
+  },
+  {
+    id: 'score',
+    accessorKey: 'score',
+    meta: {
+      filterType: 'range' as const,
+      filterConfig: {
+        type: 'range' as const,
+        min: 0,
+        max: 100,
+        step: 1,
+        presets: [
+          { label: 'Low', min: 0, max: 33 },
+          { label: 'Medium', min: 34, max: 66 },
+          { label: 'High', min: 67, max: 100 },
+        ],
+      },
+    },
+    filterFn: rangeFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Score" />
+    ),
+  },
+  {
+    id: 'active',
+    accessorKey: 'active',
+    meta: {
+      filterType: 'boolean' as const,
+      filterConfig: {
+        type: 'boolean' as const,
+        trueLabel: 'Active',
+        falseLabel: 'Inactive',
+      },
+    },
+    filterFn: booleanFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Active" />
+    ),
+    cell: ({ row }) => (row.original.active ? 'Yes' : 'No'),
+  },
+  {
+    id: 'joinDate',
+    accessorKey: 'joinDate',
+    meta: {
+      filterType: 'date' as const,
+      filterConfig: { type: 'date' as const },
+    },
+    filterFn: dateFilterFn,
+    header: ({ column, table }) => (
+      <FilterableColumnHeader column={column} table={table} title="Join Date" />
+    ),
+    cell: ({ row }) => row.original.joinDate.toLocaleDateString(),
+  },
+];
+
+function FilterableDataTable() {
+  const { table } = useClientDataTable({
+    data: sampleData,
+    columns,
+    enableRowSelection: false,
+  });
+
+  return (
+    <div className="space-y-4">
+      <ActiveFilterChips table={table} />
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex justify-between py-4">
+        <div className="text-muted-foreground text-sm">
+          {table.getFilteredRowModel().rows.length} of {sampleData.length}{' '}
+          row(s) shown.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'DataTable/WithColumnFilters',
+  component: FilterableDataTable,
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof FilterableDataTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithColumnFilters: Story = {
+  args: {} as never,
+  render: () => <FilterableDataTable />,
+};

--- a/types/tanstack-table.d.ts
+++ b/types/tanstack-table.d.ts
@@ -1,0 +1,11 @@
+import type { RowData } from '@tanstack/react-table';
+import type { FilterConfig } from '~/components/DataTable/filters/types';
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    filterType?: 'range' | 'date' | 'boolean' | 'faceted' | 'operator';
+    filterConfig?: FilterConfig;
+    className?: string;
+  }
+}

--- a/types/tanstack-table.d.ts
+++ b/types/tanstack-table.d.ts
@@ -2,7 +2,7 @@ import type { RowData } from '@tanstack/react-table';
 import type { FilterConfig } from '~/components/DataTable/filters/types';
 
 declare module '@tanstack/react-table' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/consistent-type-definitions
   interface ColumnMeta<TData extends RowData, TValue> {
     filterType?: 'range' | 'date' | 'boolean' | 'faceted' | 'operator';
     filterConfig?: FilterConfig;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,30 @@
+import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+const mainNodeModules = path.resolve(__dirname, '../../..', 'node_modules');
+
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+    alias: {
+      // Worktree has React 18 but @testing-library/react resolves React 19
+      // from the parent repo. Alias to the parent's React 19 for consistency.
+      'react': path.resolve(mainNodeModules, 'react'),
+      'react-dom': path.resolve(mainNodeModules, 'react-dom'),
+    },
+  },
   test: {
     environment: 'jsdom',
+    server: {
+      deps: {
+        // Force all deps through Vite's resolver so React aliases apply
+        // universally. Without this, pnpm-resolved packages in the worktree
+        // link to a different React version than @testing-library/react.
+        inline: [/@tanstack/, /@testing-library/, /nuqs/],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Add a reusable filter component library for DataTable columns: **Range** (dual slider with presets), **Date** (relative presets + custom range), **Boolean** (segmented toggle), **Faceted** (multi-select), and **Operator** (entity selector + comparison conditions)
- Each column declares its filter type via TanStack Table's `meta` field — `FilterableColumnHeader` reads the config and renders the appropriate filter UI in a popover with staged Apply/Clear behavior
- Active filters shown as chips below the toolbar with individual remove buttons and "Clear all"
- Filter state persists in the URL via nuqs (`?filters=...`) so filters survive page refresh and can be shared
- Interviews table wired up with filters on protocol name, started/updated dates, progress, export status, and network entity counts

## Notes

- The `operatorFilterFn` expects aggregated network summary data (`{type, count}[]`). The worktree is based on an older commit with raw `NcNetwork` — this will work correctly after rebasing onto main which has the optimized query.
- `vitest.config.ts` has worktree-specific React version aliases that should be removed after rebase.
- 25 unit tests + 2 hook integration tests added (all passing)

## Test Plan

- [ ] Rebase onto main and resolve conflicts (query data shape, vitest config)
- [ ] Verify each filter type works: range slider, date presets, boolean toggle, faceted multi-select, operator conditions
- [ ] Verify filter chips appear/update/remove correctly
- [ ] Verify filters persist in URL on page refresh
- [ ] Verify "Clear all" removes all filters
- [ ] Run `pnpm test`, `pnpm typecheck`, `pnpm lint`
- [ ] Visual check in Storybook (`stories/DataTable.stories.tsx`)