### PR TITLE
fix(preview-upload): add headers to response

### DIFF
--- a/app/api/[version]/preview/_handlers/v1/__tests__/handler.test.ts
+++ b/app/api/[version]/preview/_handlers/v1/__tests__/handler.test.ts
@@ -131,7 +131,7 @@ type JsonBody = {
   message?: string;
   previewUrl?: string;
   protocolId?: string;
-  presignedUrls?: { assetId: string; url: string }[];
+  presignedUrls?: { assetId: string; url: string; headers: Record<string, string> }[];
 };
 
 function createPostRequest(body: unknown): NextRequest {

--- a/app/api/[version]/preview/_handlers/v1/__tests__/handler.test.ts
+++ b/app/api/[version]/preview/_handlers/v1/__tests__/handler.test.ts
@@ -134,11 +134,14 @@ type JsonBody = {
   presignedUrls?: { assetId: string; url: string; headers: Record<string, string> }[];
 };
 
-function createPostRequest(body: unknown): NextRequest {
+function createPostRequest(
+  body: unknown,
+  extraHeaders?: Record<string, string>,
+): NextRequest {
   return new NextRequest('http://localhost:3000/api/v1/preview', {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
   });
 }
 
@@ -303,6 +306,68 @@ describe('Preview API v1 handler', () => {
       expect(body.protocolId).toBe('new-protocol-id');
       expect(body.presignedUrls).toHaveLength(1);
       expect(body.presignedUrls![0]!.assetId).toBe('asset-1');
+      expect(body.presignedUrls![0]!.headers).toEqual({});
+    });
+
+    it('should echo authorization header in presigned URLs for uploadthing provider', async () => {
+      mockGetStorageProvider.mockResolvedValue('uploadthing');
+      mockValidateAndMigrateProtocol.mockResolvedValue({
+        success: true,
+        protocol: validProtocol,
+      });
+      mockPrisma.previewProtocol.findFirst.mockResolvedValue(null);
+      mockPrisma.previewProtocol.create.mockResolvedValue({
+        id: 'new-protocol-id',
+      });
+
+      const request = createPostRequest(
+        {
+          type: 'initialize-preview',
+          protocol: validProtocol,
+          assetMeta: [{ assetId: 'asset-1', name: 'image.png', size: 1024 }],
+        },
+        { Authorization: 'Bearer test-token-123' },
+      );
+
+      const response = await v1(request);
+      const body = (await response.json()) as JsonBody;
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe('job-created');
+      expect(body.presignedUrls).toHaveLength(1);
+      expect(body.presignedUrls![0]!.assetId).toBe('asset-1');
+      expect(body.presignedUrls![0]!.url).toMatch(
+        /\/api\/preview\/new-protocol-id\/upload\?/,
+      );
+      expect(body.presignedUrls![0]!.headers).toEqual({
+        Authorization: 'Bearer test-token-123',
+      });
+    });
+
+    it('should return empty headers in presigned URLs for uploadthing provider when no authorization header', async () => {
+      mockGetStorageProvider.mockResolvedValue('uploadthing');
+      mockValidateAndMigrateProtocol.mockResolvedValue({
+        success: true,
+        protocol: validProtocol,
+      });
+      mockPrisma.previewProtocol.findFirst.mockResolvedValue(null);
+      mockPrisma.previewProtocol.create.mockResolvedValue({
+        id: 'new-protocol-id',
+      });
+
+      const request = createPostRequest({
+        type: 'initialize-preview',
+        protocol: validProtocol,
+        assetMeta: [{ assetId: 'asset-1', name: 'image.png', size: 1024 }],
+      });
+
+      const response = await v1(request);
+      const body = (await response.json()) as JsonBody;
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe('job-created');
+      expect(body.presignedUrls).toHaveLength(1);
+      expect(body.presignedUrls![0]!.headers).toEqual({});
     });
 
     it('should prune old preview protocols before creating new ones', async () => {

--- a/app/api/[version]/preview/_handlers/v1/handler.ts
+++ b/app/api/[version]/preview/_handlers/v1/handler.ts
@@ -199,11 +199,15 @@ export async function v1(request: NextRequest) {
           presignedUrls = newAssets.map((asset, i) => ({
             assetId: asset.assetId,
             url: s3Presigned[i]!.uploadUrl,
-            requiresAuth: false,
+            headers: {},
           }));
         } else if (provider === 'uploadthing') {
           const publicBase = env.PUBLIC_URL ?? request.nextUrl.origin;
           const baseOrigin = new URL(publicBase).origin;
+          const authHeader = request.headers.get('authorization');
+          const uploadHeaders: Record<string, string> = authHeader
+            ? { Authorization: authHeader }
+            : {};
           presignedUrls = newAssets.map((asset) => {
             const manifestEntry = assetManifest[asset.assetId];
             const assetType = manifestEntry?.type ?? 'file';
@@ -216,7 +220,7 @@ export async function v1(request: NextRequest) {
             return {
               assetId: asset.assetId,
               url: `${baseOrigin}/api/preview/${protocol.id}/upload?${params.toString()}`,
-              requiresAuth: true,
+              headers: uploadHeaders,
             };
           });
         }

--- a/app/api/[version]/preview/_handlers/v1/handler.ts
+++ b/app/api/[version]/preview/_handlers/v1/handler.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { after, type NextRequest } from 'next/server';
 import { hash } from 'ohash';
 import { addEvent } from '~/actions/activityFeed';
@@ -7,7 +8,6 @@ import { prisma } from '~/lib/db';
 import { Prisma } from '~/lib/db/generated/client';
 import { captureException, shutdownPostHog } from '~/lib/posthog-server';
 import { validateAndMigrateProtocol } from '~/lib/protocol/validateAndMigrateProtocol';
-import { Effect } from 'effect';
 import { getStorageLayer } from '~/lib/storage/layers/StorageLayer';
 import { AssetStorage } from '~/lib/storage/services/AssetStorage';
 import { getExistingAssets } from '~/queries/protocols';
@@ -192,12 +192,19 @@ export async function v1(request: NextRequest) {
         // Build upload URLs for the response. S3 returns real presigned
         // URLs; UploadThing returns proxy URLs that route back to our
         // own server, which uploads via UTApi on behalf of the client.
-        let presignedUrls: { assetId: string; url: string }[] = [];
+        let presignedUrls: {
+          assetId: string;
+          url: string;
+          requiresAuth: boolean;
+          bodyFormat: 'raw' | 'formdata';
+        }[] = [];
 
         if (provider === 's3') {
           presignedUrls = newAssets.map((asset, i) => ({
             assetId: asset.assetId,
             url: s3Presigned[i]!.uploadUrl,
+            requiresAuth: false,
+            bodyFormat: 'formdata',
           }));
         } else if (provider === 'uploadthing') {
           const publicBase = env.PUBLIC_URL ?? request.nextUrl.origin;
@@ -214,6 +221,8 @@ export async function v1(request: NextRequest) {
             return {
               assetId: asset.assetId,
               url: `${baseOrigin}/api/preview/${protocol.id}/upload?${params.toString()}`,
+              requiresAuth: true,
+              bodyFormat: 'raw',
             };
           });
         }

--- a/app/api/[version]/preview/_handlers/v1/handler.ts
+++ b/app/api/[version]/preview/_handlers/v1/handler.ts
@@ -196,7 +196,6 @@ export async function v1(request: NextRequest) {
           assetId: string;
           url: string;
           requiresAuth: boolean;
-          bodyFormat: 'raw' | 'formdata';
         }[] = [];
 
         if (provider === 's3') {
@@ -204,7 +203,6 @@ export async function v1(request: NextRequest) {
             assetId: asset.assetId,
             url: s3Presigned[i]!.uploadUrl,
             requiresAuth: false,
-            bodyFormat: 'formdata',
           }));
         } else if (provider === 'uploadthing') {
           const publicBase = env.PUBLIC_URL ?? request.nextUrl.origin;
@@ -222,7 +220,6 @@ export async function v1(request: NextRequest) {
               assetId: asset.assetId,
               url: `${baseOrigin}/api/preview/${protocol.id}/upload?${params.toString()}`,
               requiresAuth: true,
-              bodyFormat: 'raw',
             };
           });
         }

--- a/app/api/[version]/preview/_handlers/v1/handler.ts
+++ b/app/api/[version]/preview/_handlers/v1/handler.ts
@@ -19,6 +19,7 @@ import {
   type AbortResponse,
   type CompleteResponse,
   type InitializeResponse,
+  type PresignedUrlWithAssetId,
   type PreviewRequest,
   type ReadyResponse,
   type RejectedResponse,
@@ -192,11 +193,7 @@ export async function v1(request: NextRequest) {
         // Build upload URLs for the response. S3 returns real presigned
         // URLs; UploadThing returns proxy URLs that route back to our
         // own server, which uploads via UTApi on behalf of the client.
-        let presignedUrls: {
-          assetId: string;
-          url: string;
-          requiresAuth: boolean;
-        }[] = [];
+        let presignedUrls: PresignedUrlWithAssetId[] = [];
 
         if (provider === 's3') {
           presignedUrls = newAssets.map((asset, i) => ({

--- a/app/api/[version]/preview/_handlers/v1/types.ts
+++ b/app/api/[version]/preview/_handlers/v1/types.ts
@@ -40,8 +40,8 @@ export type PreviewRequest =
 export type PresignedUrlWithAssetId = {
   assetId: string;
   url: string;
-  /** Whether the client must attach its Bearer token to the upload PUT request. */
-  requiresAuth: boolean;
+  /** Headers the client must include on the upload PUT request. */
+  headers: Record<string, string>;
 };
 
 type JobCreatedResponse = {

--- a/app/api/[version]/preview/_handlers/v1/types.ts
+++ b/app/api/[version]/preview/_handlers/v1/types.ts
@@ -37,7 +37,7 @@ export type PreviewRequest =
 
 // RESPONSE TYPES
 
-type PresignedUrlWithAssetId = {
+export type PresignedUrlWithAssetId = {
   assetId: string;
   url: string;
   /** Whether the client must attach its Bearer token to the upload PUT request. */

--- a/app/api/[version]/preview/_handlers/v1/types.ts
+++ b/app/api/[version]/preview/_handlers/v1/types.ts
@@ -42,8 +42,6 @@ type PresignedUrlWithAssetId = {
   url: string;
   /** Whether the client must attach its Bearer token to the upload PUT request. */
   requiresAuth: boolean;
-  /** How to encode the file in the request body. */
-  bodyFormat: 'raw' | 'formdata';
 };
 
 type JobCreatedResponse = {

--- a/app/api/[version]/preview/_handlers/v1/types.ts
+++ b/app/api/[version]/preview/_handlers/v1/types.ts
@@ -40,6 +40,10 @@ export type PreviewRequest =
 type PresignedUrlWithAssetId = {
   assetId: string;
   url: string;
+  /** Whether the client must attach its Bearer token to the upload PUT request. */
+  requiresAuth: boolean;
+  /** How to encode the file in the request body. */
+  bodyFormat: 'raw' | 'formdata';
 };
 
 type JobCreatedResponse = {


### PR DESCRIPTION
Specifies upload contract so that the consumer can pass headers if needed without needing to know storage provider from url



This pull request enhances the handling of presigned URLs for asset uploads in the Preview API v1. The main focus is on ensuring that any required headers, such as authorization, are correctly included in the presigned URL response, especially when using the "uploadthing" storage provider. The changes improve both the API implementation and its test coverage.

**API enhancements:**

* The `PresignedUrlWithAssetId` type now includes a `headers` field, allowing the backend to specify headers (like `Authorization`) that clients must include when uploading assets. ([app/api/[version]/preview/_handlers/v1/types.tsL40-R44](diffhunk://#diff-b74fa6c5eac7b9b19c516c71e756d3342119c1e63dab2a5acd39f7565904a695L40-R44))
* The API handler (`v1`) populates the `headers` field for presigned URLs: it includes the `Authorization` header if present in the request, or an empty object otherwise, specifically for the "uploadthing" provider. ([app/api/[version]/preview/_handlers/v1/handler.tsL195-R210](diffhunk://#diff-4eee19618a1c80ca1d1054b2feb51272c72328cbe522753967600579bf285781L195-R210), [app/api/[version]/preview/_handlers/v1/handler.tsR223](diffhunk://#diff-4eee19618a1c80ca1d1054b2feb51272c72328cbe522753967600579bf285781R223))

**Test improvements:**

* Unit tests in `handler.test.ts` verify that the `headers` field is correctly set in presigned URLs—both when an `Authorization` header is provided and when it is absent. ([app/api/[version]/preview/_handlers/v1/__tests__/handler.test.tsR309-R370](diffhunk://#diff-bb94b854f113defc2294dbd87060c542c376f53f2f8889172693f31718fc7ba8R309-R370))
* The `JsonBody` test type and `createPostRequest` helper are updated to support and check the new `headers` field in presigned URLs. ([app/api/[version]/preview/_handlers/v1/__tests__/handler.test.tsL134-R144](diffhunk://#diff-bb94b854f113defc2294dbd87060c542c376f53f2f8889172693f31718fc7ba8L134-R144))

**Code maintenance:**

* Minor import cleanup and type export adjustments to support the above changes. ([app/api/[version]/preview/_handlers/v1/handler.tsR1](diffhunk://#diff-4eee19618a1c80ca1d1054b2feb51272c72328cbe522753967600579bf285781R1), [app/api/[version]/preview/_handlers/v1/handler.tsL10](diffhunk://#diff-4eee19618a1c80ca1d1054b2feb51272c72328cbe522753967600579bf285781L10), [app/api/[version]/preview/_handlers/v1/handler.tsR22](diffhunk://#diff-4eee19618a1c80ca1d1054b2feb51272c72328cbe522753967600579bf285781R22))