### PR TITLE
Fix: Respect categorical option value 0 across node drawer and filter rules

### DIFF
--- a/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isUncategorised } from '~/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins';
+
+describe('isUncategorised', () => {
+  it.each([0, false, ''])(
+    'treats a node with falsy value %p on the active variable as categorised',
+    (value) => {
+      expect(isUncategorised({ v: value }, 'v', undefined)).toBe(false);
+    },
+  );
+
+  it('treats null on the active variable as uncategorised', () => {
+    expect(isUncategorised({ v: null }, 'v', undefined)).toBe(true);
+  });
+
+  it('treats a missing active variable as uncategorised', () => {
+    expect(isUncategorised({}, 'v', undefined)).toBe(true);
+  });
+
+  it('treats a node with only the other variable set as categorised', () => {
+    expect(isUncategorised({ o: 'custom' }, 'v', 'o')).toBe(false);
+  });
+
+  it('treats a falsy other variable value as categorised', () => {
+    expect(isUncategorised({ o: 0 }, 'v', 'o')).toBe(false);
+  });
+
+  it('treats both variables unset as uncategorised', () => {
+    expect(isUncategorised({}, 'v', 'o')).toBe(true);
+    expect(isUncategorised({ v: null, o: null }, 'v', 'o')).toBe(true);
+  });
+});

--- a/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { isUncategorised } from '~/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins';
 
 describe('isUncategorised', () => {
-  it.each([0, false])(
-    'treats a node with falsy value %p on the active variable as categorised',
-    (value) => {
-      expect(isUncategorised({ v: value }, 'v', undefined)).toBe(false);
-    },
-  );
+  it('treats a node with stored 0 on the active variable as categorised', () => {
+    expect(isUncategorised({ v: 0 }, 'v', undefined)).toBe(false);
+  });
 
   it('treats null on the active variable as uncategorised', () => {
     expect(isUncategorised({ v: null }, 'v', undefined)).toBe(true);

--- a/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
@@ -29,4 +29,16 @@ describe('isUncategorised', () => {
     expect(isUncategorised({}, 'v', 'o')).toBe(true);
     expect(isUncategorised({ v: null, o: null }, 'v', 'o')).toBe(true);
   });
+
+  it('treats an empty array on the active variable as uncategorised', () => {
+    expect(isUncategorised({ v: [] }, 'v', undefined)).toBe(true);
+  });
+
+  it('treats a non-empty array on the active variable as categorised', () => {
+    expect(isUncategorised({ v: ['a'] }, 'v', undefined)).toBe(false);
+  });
+
+  it('treats an empty array on the other variable as uncategorised', () => {
+    expect(isUncategorised({ o: [] }, 'v', 'o')).toBe(true);
+  });
 });

--- a/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/__tests__/useCategoricalBins.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { isUncategorised } from '~/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins';
 
 describe('isUncategorised', () => {
-  it.each([0, false, ''])(
+  it.each([0, false])(
     'treats a node with falsy value %p on the active variable as categorised',
     (value) => {
       expect(isUncategorised({ v: value }, 'v', undefined)).toBe(false);

--- a/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
@@ -1,5 +1,6 @@
 import { type Stage } from '@codaco/protocol-validation';
 import { entityAttributesProperty, type NcNode } from '@codaco/shared-consts';
+import { isNil } from 'es-toolkit';
 import { get } from 'es-toolkit/compat';
 import { useSelector } from 'react-redux';
 import { usePrompts } from '../../components/Prompts/usePrompts';
@@ -33,16 +34,26 @@ type CategoricalBinPrompts = Extract<
   { type: 'CategoricalBin' }
 >['prompts'][number];
 
+// An empty array is treated as unset: a CheckboxGroup stage may leave `[]`
+// behind when all options are deselected, and such a node would otherwise
+// match no bin (matchVariableValue's some() returns false for []) *and*
+// be filtered out of the drawer, making it invisible.
+function hasValue(value: unknown): boolean {
+  if (isNil(value)) return false;
+  if (Array.isArray(value) && value.length === 0) return false;
+  return true;
+}
+
 export function isUncategorised(
   attributes: NcNode[typeof entityAttributesProperty],
   activePromptVariable: string | undefined,
   otherVariable: string | undefined,
 ) {
   const activeVarExists = activePromptVariable
-    ? attributes[activePromptVariable] != null
+    ? hasValue(attributes[activePromptVariable])
     : false;
   const otherVarExists = otherVariable
-    ? attributes[otherVariable] != null
+    ? hasValue(attributes[otherVariable])
     : false;
 
   return !activeVarExists && !otherVarExists;
@@ -68,7 +79,8 @@ export function useCategoricalBins() {
       ? variableDefinition.options!
       : [];
 
-  // Calcualte uncategorised nodes by filtering stageNodes to those that don't have a value for either the active prompt variable or the other variable
+  // Calculate uncategorised nodes by filtering stageNodes to those that
+  // don't have a value for either the active prompt variable or the other variable
   const uncategorisedNodes = stageNodes.filter((node) =>
     isUncategorised(
       node[entityAttributesProperty],

--- a/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
@@ -33,6 +33,21 @@ type CategoricalBinPrompts = Extract<
   { type: 'CategoricalBin' }
 >['prompts'][number];
 
+export function isUncategorised(
+  attributes: NcNode[typeof entityAttributesProperty],
+  activePromptVariable: string | undefined,
+  otherVariable: string | undefined,
+) {
+  const activeVarExists = activePromptVariable
+    ? attributes[activePromptVariable] != null
+    : false;
+  const otherVarExists = otherVariable
+    ? attributes[otherVariable] != null
+    : false;
+
+  return !activeVarExists && !otherVarExists;
+}
+
 export function useCategoricalBins() {
   const stageNodes = useSelector(getNetworkNodesForType);
   const {
@@ -53,19 +68,14 @@ export function useCategoricalBins() {
       ? variableDefinition.options!
       : [];
 
-  // Calculate uncategorised nodes by filtering stageNodes to those that don't have a value for either the active prompt variable or the other variable
-  const uncategorisedNodes = stageNodes.filter((node) => {
-    const attributes = node[entityAttributesProperty];
-
-    const activeVarExists = activePromptVariable
-      ? attributes[activePromptVariable] != null
-      : false;
-    const otherVarExists = otherVariable
-      ? attributes[otherVariable] != null
-      : false;
-
-    return !activeVarExists && !otherVarExists;
-  });
+  // Calcualte uncategorised nodes by filtering stageNodes to those that don't have a value for either the active prompt variable or the other variable
+  const uncategorisedNodes = stageNodes.filter((node) =>
+    isUncategorised(
+      node[entityAttributesProperty],
+      activePromptVariable,
+      otherVariable,
+    ),
+  );
 
   const sortedUncategorisedNodes = useSortedNodeList(
     uncategorisedNodes,

--- a/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
@@ -112,7 +112,7 @@ export function useCategoricalBins() {
   // Handle 'other' bin
   if (otherVariable && otherOptionLabel) {
     const otherNodes = stageNodes.filter(
-      (node) => get(node, [entityAttributesProperty, otherVariable]) != null,
+      (node) => !isNil(get(node, [entityAttributesProperty, otherVariable])),
     );
 
     const sortedOtherNodes = getSortedNodeList(

--- a/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
+++ b/lib/interviewer/Interfaces/CategoricalBin/useCategoricalBins.ts
@@ -58,9 +58,11 @@ export function useCategoricalBins() {
     const attributes = node[entityAttributesProperty];
 
     const activeVarExists = activePromptVariable
-      ? !!attributes[activePromptVariable]
+      ? attributes[activePromptVariable] != null
       : false;
-    const otherVarExists = otherVariable ? !!attributes[otherVariable] : false;
+    const otherVarExists = otherVariable
+      ? attributes[otherVariable] != null
+      : false;
 
     return !activeVarExists && !otherVarExists;
   });

--- a/lib/network-exporters/utils/__tests__/general.test.ts
+++ b/lib/network-exporters/utils/__tests__/general.test.ts
@@ -2,14 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { isCategoricalOptionSelected } from '~/lib/network-exporters/utils/general';
 
 describe('isCategoricalOptionSelected', () => {
-  // CategoricalBin writes scalar option values, so a stored `0` or `false`
-  // must still match the corresponding option on export.
+  // CategoricalBin writes scalar option values, so a stored `0` must still
+  // match the corresponding option on export.
   it('treats stored 0 as selected when option value is 0', () => {
     expect(isCategoricalOptionSelected(0, 0)).toBe(true);
-  });
-
-  it('treats stored false as selected when option value is false', () => {
-    expect(isCategoricalOptionSelected(false, false)).toBe(true);
   });
 
   it('treats stored 0 as not selected for a different option value', () => {

--- a/lib/network-exporters/utils/__tests__/general.test.ts
+++ b/lib/network-exporters/utils/__tests__/general.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isCategoricalOptionSelected } from '~/lib/network-exporters/utils/general';
+
+describe('isCategoricalOptionSelected', () => {
+  // CategoricalBin writes scalar option values, so a stored `0` or `false`
+  // must still match the corresponding option on export.
+  it('treats stored 0 as selected when option value is 0', () => {
+    expect(isCategoricalOptionSelected(0, 0)).toBe(true);
+  });
+
+  it('treats stored false as selected when option value is false', () => {
+    expect(isCategoricalOptionSelected(false, false)).toBe(true);
+  });
+
+  it('treats stored 0 as not selected for a different option value', () => {
+    expect(isCategoricalOptionSelected(0, 1)).toBe(false);
+  });
+
+  // CheckboxGroup stores arrays; a falsy element must still match.
+  it('treats [0] as selected when option value is 0', () => {
+    expect(isCategoricalOptionSelected([0], 0)).toBe(true);
+  });
+
+  it('treats null as not selected', () => {
+    expect(isCategoricalOptionSelected(null, 0)).toBe(false);
+  });
+
+  it('treats undefined as not selected', () => {
+    expect(isCategoricalOptionSelected(undefined, 0)).toBe(false);
+  });
+});

--- a/lib/network-exporters/utils/general.ts
+++ b/lib/network-exporters/utils/general.ts
@@ -4,6 +4,7 @@ import {
   type NcEntity,
   sessionProperty,
 } from '@codaco/shared-consts';
+import { isNil } from 'es-toolkit';
 import sanitizeFilename from 'sanitize-filename';
 import type { ExportFormat, SessionWithResequencedIDs } from './types';
 
@@ -72,15 +73,15 @@ export const isCategoricalOptionSelected = (
   attributeData: unknown,
   optionValue: string | number | boolean,
 ): boolean => {
-  if (!attributeData) {
+  // isNil, not `!attributeData`: a stored `0` / `false` is a valid option
+  // value that must reach the equality / includes checks below.
+  if (isNil(attributeData)) {
     return false;
   }
 
-  // If it's an array, use Array.prototype.includes (strict equality)
   if (Array.isArray(attributeData)) {
     return attributeData.includes(optionValue);
   }
 
-  // If it's a single value (string, number, or boolean), check for exact equality
   return attributeData === optionValue;
 };

--- a/lib/network-query/__tests__/predicate.test.js
+++ b/lib/network-query/__tests__/predicate.test.js
@@ -275,19 +275,13 @@ describe('predicate', () => {
 
       it('Falsy scalar value', () => {
         // CategoricalBin and OrdinalBin write scalar option values, so a
-        // stored `0` or `false` must still reach the equality check.
+        // stored `0` must still reach the equality check.
         expect(predicate(operators.INCLUDES)({ value: 0, other: 0 })).toBe(
           true,
         );
         expect(predicate(operators.INCLUDES)({ value: 0, other: 1 })).toBe(
           false,
         );
-        expect(
-          predicate(operators.INCLUDES)({ value: false, other: false }),
-        ).toBe(true);
-        expect(
-          predicate(operators.INCLUDES)({ value: false, other: true }),
-        ).toBe(false);
 
         // null / undefined remain "unset" — not included.
         expect(predicate(operators.INCLUDES)({ value: null, other: 0 })).toBe(
@@ -374,20 +368,14 @@ describe('predicate', () => {
       });
 
       it('Falsy scalar value', () => {
-        // Mirror of INCLUDES: stored `0` / `false` must reach the equality
-        // check rather than falling into the nil short-circuit.
+        // Mirror of INCLUDES: stored `0` must reach the equality check
+        // rather than falling into the nil short-circuit.
         expect(predicate(operators.EXCLUDES)({ value: 0, other: 0 })).toBe(
           false,
         );
         expect(predicate(operators.EXCLUDES)({ value: 0, other: 1 })).toBe(
           true,
         );
-        expect(
-          predicate(operators.EXCLUDES)({ value: false, other: false }),
-        ).toBe(false);
-        expect(
-          predicate(operators.EXCLUDES)({ value: false, other: true }),
-        ).toBe(true);
 
         // null / undefined remain "unset" — vacuously excluded.
         expect(predicate(operators.EXCLUDES)({ value: null, other: 0 })).toBe(

--- a/lib/network-query/__tests__/predicate.test.js
+++ b/lib/network-query/__tests__/predicate.test.js
@@ -272,6 +272,31 @@ describe('predicate', () => {
           false,
         );
       });
+
+      it('Falsy scalar value', () => {
+        // CategoricalBin and OrdinalBin write scalar option values, so a
+        // stored `0` or `false` must still reach the equality check.
+        expect(predicate(operators.INCLUDES)({ value: 0, other: 0 })).toBe(
+          true,
+        );
+        expect(predicate(operators.INCLUDES)({ value: 0, other: 1 })).toBe(
+          false,
+        );
+        expect(
+          predicate(operators.INCLUDES)({ value: false, other: false }),
+        ).toBe(true);
+        expect(
+          predicate(operators.INCLUDES)({ value: false, other: true }),
+        ).toBe(false);
+
+        // null / undefined remain "unset" — not included.
+        expect(predicate(operators.INCLUDES)({ value: null, other: 0 })).toBe(
+          false,
+        );
+        expect(
+          predicate(operators.INCLUDES)({ value: undefined, other: 0 }),
+        ).toBe(false);
+      });
     });
 
     // True if other is not included in value
@@ -346,6 +371,31 @@ describe('predicate', () => {
         expect(predicate(operators.EXCLUDES)({ value: 6, other: 6 })).toBe(
           false,
         );
+      });
+
+      it('Falsy scalar value', () => {
+        // Mirror of INCLUDES: stored `0` / `false` must reach the equality
+        // check rather than falling into the nil short-circuit.
+        expect(predicate(operators.EXCLUDES)({ value: 0, other: 0 })).toBe(
+          false,
+        );
+        expect(predicate(operators.EXCLUDES)({ value: 0, other: 1 })).toBe(
+          true,
+        );
+        expect(
+          predicate(operators.EXCLUDES)({ value: false, other: false }),
+        ).toBe(false);
+        expect(
+          predicate(operators.EXCLUDES)({ value: false, other: true }),
+        ).toBe(true);
+
+        // null / undefined remain "unset" — vacuously excluded.
+        expect(predicate(operators.EXCLUDES)({ value: null, other: 0 })).toBe(
+          true,
+        );
+        expect(
+          predicate(operators.EXCLUDES)({ value: undefined, other: 0 }),
+        ).toBe(true);
       });
 
       it('Empty array edges', () => {

--- a/lib/network-query/predicate.ts
+++ b/lib/network-query/predicate.ts
@@ -1,4 +1,4 @@
-import { isEqual, isNull } from 'es-toolkit';
+import { isEqual, isNil, isNull } from 'es-toolkit';
 
 export const operators = {
   EXACTLY: 'EXACTLY',
@@ -117,9 +117,11 @@ const predicate =
        * If you change these, make sure you test all the cases!
        */
       case operators.INCLUDES: {
-        if (!value) {
+        // isNil, not `!value`: stored `0` / `false` are valid option values
+        // and must reach the equality checks below.
+        if (isNil(value)) {
           return false;
-        } // ord/cat vars are initialised to null
+        }
 
         if (Array.isArray(variableValue)) {
           if (Array.isArray(value)) {
@@ -137,9 +139,10 @@ const predicate =
         return value === variableValue;
       }
       case operators.EXCLUDES: {
-        if (!value) {
+        // See INCLUDES for why this is isNil, not `!value`.
+        if (isNil(value)) {
           return true;
-        } // ord/cat vars are initialised to null
+        }
 
         if (Array.isArray(variableValue)) {
           if (Array.isArray(value)) {


### PR DESCRIPTION
This PR addresses several bugs related to categorical bin variables with falsy values ( `0` is configurable in Architect web and desktop):

**Bug 1: CategoricalBin node drawer**
On CategoricalBin stages, dropping a node into a bin with a falsy `value` ( `0`) did not remove it from the uncategorized drawer. Dragging a node from another bin into that bin made the node reappear in the drawer. This was due to using `!!attributes[variable]` for the uncategorized nodes filter.

Fix: Switch to` isNil()` for the filter, consistent with approach in Ordinal Bins. Refactor to extract into a helper for easier testing, and add unit tests to cover regressions.

**Bug 2: Filter rules**
The same kind of bug was in the filter predicate. INCLUDES and EXCLUDES used `!value`, so a rule like INCLUDES `0`, where `0` is a value of a categorical variable, excluded every node which had the stored attribute as `0`.

Fix: Switch to `isNil()` for filters, and add unit tests.

**Bug 3: Export**
Exported data where a categorical attribute's value was `0` or `false` showed the option column as `FALSE` in exported data. Same issue,`isCategoricalOptionSelected` used `!attributeData. Only impacts single value categorical variables (categorical bins). 

Fix: Fix: Switch to `isNil()` in `isCategoricalOptionSelected`, and add unit tests covering stored `0` / `[0]` / `null`.