### PR TITLE
fix(signup): allow show/hide toggle on confirm password field

### DIFF
--- a/app/(blobs)/(setup)/_components/SignUpForm.tsx
+++ b/app/(blobs)/(setup)/_components/SignUpForm.tsx
@@ -188,7 +188,6 @@ export const SignUpForm = ({ sandboxMode = false }: SignUpFormProps) => {
             placeholder="******************"
             sameAs="password"
             component={PasswordField}
-            type="password"
             autoComplete="do-not-autofill"
           />
         </FieldGroup>

--- a/lib/form/components/fields/PasswordField.tsx
+++ b/lib/form/components/fields/PasswordField.tsx
@@ -6,7 +6,10 @@ import ProgressBar from '~/components/ui/ProgressBar';
 import InputField from '~/lib/form/components/fields/InputField';
 import { cx } from '~/utils/cva';
 
-type PasswordFieldProps = React.ComponentProps<typeof InputField> & {
+type PasswordFieldProps = Omit<
+  React.ComponentProps<typeof InputField>,
+  'type'
+> & {
   showStrengthMeter?: boolean;
 };
 


### PR DESCRIPTION
`type=password `passed from `SignUpForm` overrode `PasswordField`'s internal show/hide toggle, so the Eye icon did nothing on confirm. `PasswordField` handles type internally