### PR TITLE
Fix/quickadd lucide icon sizing

### DIFF
--- a/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
@@ -10,12 +10,7 @@ import type { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
 import NodeForm from './NodeForm';
 
-const customIconOptions = [
-  'add-a-person',
-  'add-a-place',
-  'add-a-context',
-  'add-a-relationship',
-];
+const customIconOptions = ['add-a-person', 'add-a-place'];
 
 const iconOptions = [...customIconOptions, ...Object.keys(icons)];
 

--- a/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
@@ -5,18 +5,31 @@ import {
 } from '@codaco/shared-consts';
 import { configureStore } from '@reduxjs/toolkit';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { icons } from 'lucide-react';
+import type { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
 import NodeForm from './NodeForm';
 
+const customIconOptions = [
+  'add-a-person',
+  'add-a-place',
+  'add-a-context',
+  'add-a-relationship',
+];
+
+const iconOptions = [...customIconOptions, ...Object.keys(icons)];
+
+type StoryArgs = ComponentProps<typeof NodeForm> & { icon: string };
+
 // Mock data for the story
-const mockProtocol = {
+const buildMockProtocol = (icon: string) => ({
   name: 'Test Protocol',
   codebook: {
     node: {
       person: {
         name: 'Person',
         displayVariable: 'name',
-        iconVariant: 'add-a-person',
+        icon,
         variables: {
           name: {
             name: 'Name',
@@ -193,7 +206,7 @@ const mockProtocol = {
       },
     },
   ],
-};
+});
 
 // Create a proper mock session that matches the expected structure
 const mockSession = {
@@ -236,7 +249,11 @@ const mockSession = {
 };
 
 // Create mock Redux store with proper structure
-const createMockStore = (overrides: Record<string, unknown> = {}) => {
+const createMockStore = (
+  icon: string,
+  overrides: Record<string, unknown> = {},
+) => {
+  const mockProtocol = buildMockProtocol(icon);
   const mockProtocolState = {
     id: 'test-protocol-id',
     codebook: mockProtocol.codebook,
@@ -271,9 +288,13 @@ const createMockStore = (overrides: Record<string, unknown> = {}) => {
 // Story decorator to provide Redux store
 const ReduxDecorator = (
   Story: React.ComponentType,
-  context: { parameters?: { reduxState?: unknown } },
+  context: {
+    args: { icon?: string };
+    parameters?: { reduxState?: unknown };
+  },
 ) => {
   const store = createMockStore(
+    context.args.icon ?? 'add-a-person',
     context.parameters?.reduxState as Record<string, unknown> | undefined,
   );
   return (
@@ -285,14 +306,23 @@ const ReduxDecorator = (
   );
 };
 
-const meta: Meta<typeof NodeForm> = {
+const meta: Meta<StoryArgs> = {
   title: 'Interview/Interfaces/NameGenerator/NodeForm',
   component: NodeForm,
   decorators: [ReduxDecorator],
   parameters: {
     layout: 'centered',
   },
+  args: {
+    icon: 'add-a-person',
+  },
   argTypes: {
+    icon: {
+      control: 'select',
+      options: iconOptions,
+      description:
+        'Icon for the node type (story-only — drives the redux codebook mock).',
+    },
     selectedNode: {
       control: 'object',
       description: 'The node being edited, or null for creating a new node',
@@ -317,7 +347,7 @@ const meta: Meta<typeof NodeForm> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<StoryArgs>;
 
 // Basic form with all field types
 const basicForm: TForm = {

--- a/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.stories.tsx
@@ -306,6 +306,7 @@ const meta: Meta<StoryArgs> = {
   component: NodeForm,
   decorators: [ReduxDecorator],
   parameters: {
+    forceTheme: 'interview',
     layout: 'centered',
   },
   args: {

--- a/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.tsx
@@ -158,7 +158,7 @@ const NodeForm = (props: NodeFormProps) => {
               </motion.div>
             </motion.div>
             <motion.div className={actionPlusBadgeVariants()}>
-              <Plus className={actionPlusIconClass} size={12} />
+              <Plus className={actionPlusIconClass} />
             </motion.div>
           </button>
         </motion.div>

--- a/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/NodeForm.tsx
@@ -20,6 +20,12 @@ import { type FormSubmitHandler } from '@codaco/fresco-ui/form/store/types';
 import { updateNode as updateNodeAction } from '~/lib/interviewer/ducks/modules/session';
 import { useCelebrate } from '~/lib/interviewer/hooks/useCelebrate';
 import { cx } from '@codaco/fresco-ui/utils/cva';
+import {
+  actionCircleVariants,
+  actionIconClass,
+  actionPlusBadgeVariants,
+  actionPlusIconClass,
+} from '~/lib/interviewer/components/actionButtonVariants';
 import { getNodeIconName } from '../../../selectors/name-generator';
 import { getPromptAdditionalAttributes } from '../../../selectors/session';
 import { useAppDispatch } from '../../../store';
@@ -138,20 +144,21 @@ const NodeForm = (props: NodeFormProps) => {
               ref={circleRef}
               data-toggle-circle
               className={cx(
-                'elevation-high relative flex aspect-square size-28 items-center justify-center overflow-hidden rounded-full transition-[background-color,filter] duration-300 [&>.lucide]:aspect-square [&>.lucide]:h-16 [&>.lucide]:w-auto',
+                actionCircleVariants(),
+                'relative aspect-square size-28 transition-[background-color,filter] duration-300',
                 disabled ? 'cursor-not-allowed saturate-0' : 'cursor-pointer',
               )}
               style={{ backgroundColor: 'var(--primary)' }}
             >
-              <motion.div className="h-full">
+              <motion.div className="flex h-full items-center justify-center">
                 <Icon
                   name={icon as InterviewerIconName}
-                  className="h-full w-auto"
+                  className={actionIconClass}
                 />
               </motion.div>
             </motion.div>
-            <motion.div className="bg-platinum text-charcoal absolute -top-2 -right-4 flex size-10 items-center justify-center rounded-full shadow-lg">
-              <Plus className="size-6" size={12} />
+            <motion.div className={actionPlusBadgeVariants()}>
+              <Plus className={actionPlusIconClass} size={12} />
             </motion.div>
           </button>
         </motion.div>

--- a/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
@@ -1,13 +1,26 @@
+import Form from '@codaco/fresco-ui/form/Form';
+import { type FormSubmitHandler } from '@codaco/fresco-ui/form/store/types';
 import { configureStore } from '@reduxjs/toolkit';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { icons } from 'lucide-react';
+import type { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
 import { action } from 'storybook/actions';
 import { fn } from 'storybook/test';
-import Form from '@codaco/fresco-ui/form/Form';
-import { type FormSubmitHandler } from '@codaco/fresco-ui/form/store/types';
 import QuickAddField from './QuickAddField';
 
-const mockProtocol = {
+const customIconOptions = [
+  'add-a-person',
+  'add-a-place',
+  'add-a-context',
+  'add-a-relationship',
+];
+
+const iconOptions = [...customIconOptions, ...Object.keys(icons)];
+
+type StoryArgs = ComponentProps<typeof QuickAddField> & { icon: string };
+
+const buildMockProtocol = (icon: string) => ({
   id: 'test-protocol',
   codebook: {
     node: {
@@ -15,7 +28,7 @@ const mockProtocol = {
         name: 'Person',
         color: 'node-color-seq-1',
         displayVariable: 'name',
-        iconVariant: 'add-a-person',
+        icon,
         variables: {
           name: {
             name: 'Name',
@@ -46,7 +59,7 @@ const mockProtocol = {
     encryptedVariables: false,
   },
   assets: [],
-};
+});
 
 const mockSession = {
   id: 'test-session',
@@ -61,7 +74,9 @@ const mockSession = {
   },
 };
 
-const createMockStore = () => {
+const createMockStore = (icon: string) => {
+  const mockProtocol = buildMockProtocol(icon);
+
   const mockProtocolState = {
     id: 'test-protocol-id',
     codebook: mockProtocol.codebook,
@@ -98,8 +113,11 @@ const createMockStore = () => {
   });
 };
 
-const ReduxDecorator = (Story: React.ComponentType) => {
-  const store = createMockStore();
+const ReduxDecorator = (
+  Story: React.ComponentType,
+  context: { args: { icon?: string } },
+) => {
+  const store = createMockStore(context.args.icon ?? 'add-a-person');
   return (
     <Provider store={store}>
       <div className="relative flex h-[400px] w-[700px] items-end justify-end bg-slate-900 p-6">
@@ -109,14 +127,23 @@ const ReduxDecorator = (Story: React.ComponentType) => {
   );
 };
 
-const meta: Meta<typeof QuickAddField> = {
+const meta: Meta<StoryArgs> = {
   title: 'Interview/Interfaces/NameGenerator/QuickAddField',
   component: QuickAddField,
   decorators: [ReduxDecorator],
   parameters: {
     layout: 'fullscreen',
   },
+  args: {
+    icon: 'add-a-person',
+  },
   argTypes: {
+    icon: {
+      control: 'select',
+      options: iconOptions,
+      description:
+        'Icon for the node type (story-only — drives the redux codebook mock).',
+    },
     name: {
       control: 'text',
       description: 'Field name (variable)',
@@ -149,7 +176,7 @@ const meta: Meta<typeof QuickAddField> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<StoryArgs>;
 
 function QuickAddFieldWrapper(
   props: React.ComponentProps<typeof QuickAddField> & {
@@ -186,7 +213,7 @@ export const Default: Story = {
     placeholder: 'Type a name and press enter...',
     disabled: false,
   },
-  render: (args) => (
+  render: ({ icon: _icon, ...args }) => (
     <QuickAddFieldWrapper {...args} onFormSubmit={formSubmitAction} />
   ),
   parameters: {
@@ -208,7 +235,7 @@ export const WithValidation: Story = {
     minLength: 2,
     maxLength: 50,
   },
-  render: (args) => (
+  render: ({ icon: _icon, ...args }) => (
     <QuickAddFieldWrapper {...args} onFormSubmit={formSubmitAction} />
   ),
   parameters: {
@@ -227,7 +254,7 @@ export const Disabled: Story = {
     placeholder: 'Type a name...',
     disabled: true,
   },
-  render: (args) => (
+  render: ({ icon: _icon, ...args }) => (
     <QuickAddFieldWrapper {...args} onFormSubmit={formSubmitAction} />
   ),
   parameters: {

--- a/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
@@ -9,12 +9,7 @@ import { action } from 'storybook/actions';
 import { fn } from 'storybook/test';
 import QuickAddField from './QuickAddField';
 
-const customIconOptions = [
-  'add-a-person',
-  'add-a-place',
-  'add-a-context',
-  'add-a-relationship',
-];
+const customIconOptions = ['add-a-person', 'add-a-place'];
 
 const iconOptions = [...customIconOptions, ...Object.keys(icons)];
 

--- a/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.stories.tsx
@@ -127,6 +127,7 @@ const meta: Meta<StoryArgs> = {
   component: QuickAddField,
   decorators: [ReduxDecorator],
   parameters: {
+    forceTheme: 'interview',
     layout: 'fullscreen',
   },
   args: {

--- a/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.tsx
@@ -24,6 +24,12 @@ import { useCelebrate } from '~/lib/interviewer/hooks/useCelebrate';
 import { getNodeIconName } from '~/lib/interviewer/selectors/name-generator';
 import { getNodeColorSelector } from '~/lib/interviewer/selectors/session';
 import { cx } from '@codaco/fresco-ui/utils/cva';
+import {
+  actionCircleVariants,
+  actionIconClass,
+  actionPlusBadgeVariants,
+  actionPlusIconClass,
+} from '~/lib/interviewer/components/actionButtonVariants';
 
 function convertToNodeColor(color: NodeColorSequence): string {
   switch (color) {
@@ -235,7 +241,8 @@ export default function QuickAddField({
               ref={circleRef}
               data-toggle-circle
               className={cx(
-                'elevation-high relative flex aspect-square size-28 items-center justify-center overflow-hidden rounded-full transition-[background-color,filter] duration-300 [&>.lucide]:aspect-square [&>.lucide]:h-16 [&>.lucide]:w-auto',
+                actionCircleVariants(),
+                'relative aspect-square size-28 transition-[background-color,filter] duration-300',
                 disabled ? 'cursor-not-allowed saturate-0' : 'cursor-pointer',
               )}
               style={{
@@ -281,25 +288,25 @@ export default function QuickAddField({
                     initial={{ y: '100%' }}
                     animate={{ y: 0 }}
                     exit={{ y: '100%' }}
-                    className="h-full"
+                    className="flex h-full items-center justify-center"
                   >
                     <Icon
                       name={icon as InterviewerIconName}
-                      className="h-full w-auto"
+                      className={actionIconClass}
                     />
                   </motion.div>
                 )}
               </AnimatePresence>
             </motion.div>
             <motion.div
-              className="bg-platinum text-charcoal absolute -top-2 -right-4 flex size-10 items-center justify-center rounded-full shadow-lg"
+              className={actionPlusBadgeVariants()}
               animate={
                 !checked || meta.isValid
                   ? { scale: 1, opacity: 1, rotate: 0 }
                   : { scale: 0, opacity: 0, rotate: 180 }
               }
             >
-              <Plus className="size-6" size={12} />
+              <Plus className={actionPlusIconClass} size={12} />
             </motion.div>
           </button>
         }

--- a/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.tsx
+++ b/lib/interviewer/Interfaces/NameGenerator/components/QuickAddField.tsx
@@ -306,7 +306,7 @@ export default function QuickAddField({
                   : { scale: 0, opacity: 0, rotate: 180 }
               }
             >
-              <Plus className={actionPlusIconClass} size={12} />
+              <Plus className={actionPlusIconClass} />
             </motion.div>
           </button>
         }

--- a/lib/interviewer/components/ActionButton.stories.tsx
+++ b/lib/interviewer/components/ActionButton.stories.tsx
@@ -70,14 +70,6 @@ export const DifferentIcons: Story = {
           <ActionButton iconName="add-a-place" />
           <span className="text-sm">add-a-place</span>
         </div>
-        <div className="flex flex-col items-center gap-2">
-          <ActionButton iconName="add-a-context" />
-          <span className="text-sm">add-a-context</span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <ActionButton iconName="add-a-relationship" />
-          <span className="text-sm">add-a-relationship</span>
-        </div>
       </div>
       <Heading level="h3" margin="none">
         Lucide icons

--- a/lib/interviewer/components/ActionButton.stories.tsx
+++ b/lib/interviewer/components/ActionButton.stories.tsx
@@ -57,30 +57,52 @@ export const Disabled: Story = {
 
 export const DifferentIcons: Story = {
   render: () => (
-    <div className="flex flex-wrap gap-8">
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="UserRound" />
-        <span className="text-sm">UserRound</span>
+    <div className="flex flex-col gap-6">
+      <Heading level="h3" margin="none">
+        Custom (kebab-case) icons
+      </Heading>
+      <div className="flex flex-wrap gap-8">
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="add-a-person" />
+          <span className="text-sm">add-a-person</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="add-a-place" />
+          <span className="text-sm">add-a-place</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="add-a-context" />
+          <span className="text-sm">add-a-context</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="add-a-relationship" />
+          <span className="text-sm">add-a-relationship</span>
+        </div>
       </div>
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="Users" />
-        <span className="text-sm">Users</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="House" />
-        <span className="text-sm">House</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="Building" />
-        <span className="text-sm">Building</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="Heart" />
-        <span className="text-sm">Heart</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <ActionButton iconName="Star" />
-        <span className="text-sm">Star</span>
+      <Heading level="h3" margin="none">
+        Lucide icons
+      </Heading>
+      <div className="flex flex-wrap gap-8">
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="UserRound" />
+          <span className="text-sm">UserRound</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="Users" />
+          <span className="text-sm">Users</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="House" />
+          <span className="text-sm">House</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="Smartphone" />
+          <span className="text-sm">Smartphone</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ActionButton iconName="BedDouble" />
+          <span className="text-sm">BedDouble</span>
+        </div>
       </div>
     </div>
   ),
@@ -114,3 +136,4 @@ export const DisabledStates: Story = {
     </div>
   ),
 };
+

--- a/lib/interviewer/components/ActionButton.tsx
+++ b/lib/interviewer/components/ActionButton.tsx
@@ -2,6 +2,12 @@ import { PlusIcon } from 'lucide-react';
 import { forwardRef } from 'react';
 import { cva, cx, type VariantProps } from '@codaco/fresco-ui/utils/cva';
 import Icon, { type InterviewerIconName } from '@codaco/fresco-ui/Icon';
+import {
+  actionCircleVariants,
+  actionIconClass,
+  actionPlusBadgeVariants,
+  actionPlusIconClass,
+} from '~/lib/interviewer/components/actionButtonVariants';
 
 const actionButtonVariants = cva({
   base: 'group focusable relative mt-2 mr-4 flex aspect-square h-26 rounded-full',
@@ -17,7 +23,10 @@ const actionButtonVariants = cva({
 });
 
 const mainIconVariants = cva({
-  base: 'bg-sea-green elevation-high absolute inset-0 flex scale-100 items-center justify-center overflow-hidden rounded-full text-white [&>.lucide]:aspect-square [&>.lucide]:h-16 [&>.lucide]:w-auto',
+  base: cx(
+    actionCircleVariants(),
+    'bg-sea-green absolute inset-0 scale-100 text-white',
+  ),
   variants: {
     disabled: {
       true: 'pointer-events-none cursor-not-allowed opacity-50',
@@ -30,12 +39,10 @@ const mainIconVariants = cva({
   },
 });
 
-const plusContainerVariants = cva({
-  base: 'bg-platinum text-charcoal absolute -top-2 -right-4 flex h-10 w-10 items-center justify-center rounded-full p-5 shadow-md',
-});
+const plusContainerVariants = actionPlusBadgeVariants;
 
 const plusIconVariants = cva({
-  base: 'h-6 w-6',
+  base: actionPlusIconClass,
   variants: {
     disabled: {
       false:
@@ -63,7 +70,7 @@ const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
         className={cx(actionButtonVariants({ disabled }), className)}
       >
         <div className={mainIconVariants({ disabled })}>
-          <Icon name={iconName} className="h-full w-auto" />
+          <Icon name={iconName} className={actionIconClass} />
         </div>
         <div className={plusContainerVariants()}>
           <div>

--- a/lib/interviewer/components/actionButtonVariants.ts
+++ b/lib/interviewer/components/actionButtonVariants.ts
@@ -2,13 +2,15 @@ import { cva } from '@codaco/fresco-ui/utils/cva';
 
 // Used by ActionButton, QuickAddField, and NodeForm.
 
+// The `[&_.lucide]` rules size Lucide icons to h-16. Custom icons (which lack
+// the `.lucide` class) fall through to actionIconClass below and fill the
+// container. Descendant (`[&_…]`) rather than direct-child (`[&>…]`) so
+// wrapper divs (e.g. AnimatePresence motion.div) don't break the selector.
 export const actionCircleVariants = cva({
-  base: 'elevation-high flex items-center justify-center overflow-hidden rounded-full',
+  base: 'elevation-high flex items-center justify-center overflow-hidden rounded-full [&_.lucide]:aspect-square [&_.lucide]:h-16 [&_.lucide]:w-auto',
 });
 
-// Set on <Icon> directly, not via a parent selector — the SVG may sit inside
-// wrapper divs (e.g. AnimatePresence motion.div) where direct-child selectors fail.
-export const actionIconClass = 'aspect-square size-16';
+export const actionIconClass = 'h-full w-auto';
 
 export const actionPlusBadgeVariants = cva({
   base: 'bg-platinum text-charcoal absolute -top-2 -right-4 flex size-10 items-center justify-center rounded-full shadow-lg',

--- a/lib/interviewer/components/actionButtonVariants.ts
+++ b/lib/interviewer/components/actionButtonVariants.ts
@@ -1,0 +1,17 @@
+import { cva } from '@codaco/fresco-ui/utils/cva';
+
+// Used by ActionButton, QuickAddField, and NodeForm.
+
+export const actionCircleVariants = cva({
+  base: 'elevation-high flex items-center justify-center overflow-hidden rounded-full',
+});
+
+// Set on <Icon> directly, not via a parent selector — the SVG may sit inside
+// wrapper divs (e.g. AnimatePresence motion.div) where direct-child selectors fail.
+export const actionIconClass = 'aspect-square size-16';
+
+export const actionPlusBadgeVariants = cva({
+  base: 'bg-platinum text-charcoal absolute -top-2 -right-4 flex size-10 items-center justify-center rounded-full shadow-lg',
+});
+
+export const actionPlusIconClass = 'size-6';


### PR DESCRIPTION
This PR standardizes the sizing/styling of Lucide vs custom (kebab-case) icons in the NameGenerator action-style buttons by extracting shared Tailwind/CVA class logic into a reusable helper and applying it across components and stories.

Changes:

- Added shared actionButtonVariants helpers to ensure consistent icon and badge sizing (including Lucide descendant selectors).
- Updated ActionButton, QuickAddField, and NodeForm to consume the shared variants/classes instead of duplicating Tailwind selectors.
- Enhanced related Storybook stories to make icon selection/testing easier across Lucide + custom icons.