### PR TITLE
ci: hardening per TanStack supply-chain postmortem + action updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@v1
+        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
 
       - name: ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       startsWith(github.event.comment.body, '/chromatic'))
+       startsWith(github.event.comment.body, '/chromatic') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       - name: Get PR details
         if: github.event_name == 'issue_comment'
@@ -57,7 +58,7 @@ jobs:
         uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
         with:
           fetch-depth: '0'
-          ref: ${{ steps.pr.outputs.ref || '' }}
+          cache-key-prefix: chromatic-pnpm-store
 
       - name: Run Chromatic
         id: chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get PR details
         if: github.event_name == 'issue_comment'
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -69,7 +69,7 @@ jobs:
 
       - name: Post links to PR
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BRANCH: ${{ steps.pr.outputs.ref }}
         with:
@@ -94,7 +94,7 @@ jobs:
 
       - name: Update commit status
         if: github.event_name == 'issue_comment' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           CHROMATIC_OUTCOME: ${{ steps.chromatic.outcome }}
           PR_SHA: ${{ steps.pr.outputs.sha }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -54,14 +54,14 @@ jobs:
             ]);
 
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@v1
+        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
         with:
           fetch-depth: '0'
           ref: ${{ steps.pr.outputs.ref || '' }}
 
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba # v16.10.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           autoAcceptChanges: main

--- a/.github/workflows/cleanup-e2e-reports.yml
+++ b/.github/workflows/cleanup-e2e-reports.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Fetch GitHub Pages content
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: pages
@@ -174,10 +174,10 @@ jobs:
 
       - name: Upload Pages artifact
         if: steps.check.outputs.has_content == 'true' && inputs.dry_run != true
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: pages/
 
       - name: Deploy to GitHub Pages
         if: steps.check.outputs.has_content == 'true' && inputs.dry_run != true
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/cleanup-e2e-reports.yml
+++ b/.github/workflows/cleanup-e2e-reports.yml
@@ -1,10 +1,5 @@
 name: Cleanup E2E Reports
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 on:
   schedule:
     # Run weekly on Sunday at 3am UTC
@@ -23,6 +18,10 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     concurrency:
       group: e2e-pages-deploy
       cancel-in-progress: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,10 +36,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Build and Push Multi-platform Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
       outcome: ${{ steps.tests.outcome }}
       slug: ${{ steps.meta.outputs.slug }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute branch slug
         id: meta
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests/e2e/playwright-report/
@@ -64,13 +64,13 @@ jobs:
       url: https://complexdatacollective.github.io/Fresco/${{ needs.e2e.outputs.slug }}/
     steps:
       - name: Download new report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: playwright-report
           path: new-report
 
       - name: Fetch existing pages content
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: existing-pages
@@ -89,15 +89,15 @@ jobs:
           mkdir -p "merged/$SLUG"
           cp -r new-report/. "merged/$SLUG/"
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: merged/
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SLUG: ${{ needs.e2e.outputs.slug }}
           OUTCOME: ${{ needs.e2e.outputs.outcome }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,6 @@ name: E2E Tests
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-  pull-requests: write
 
 on:
   push:
@@ -56,6 +53,11 @@ jobs:
     if: always()
     needs: e2e
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      pull-requests: write
     concurrency:
       group: e2e-pages-deploy
       cancel-in-progress: false

--- a/.github/workflows/netlify-cleanup-preview.yml
+++ b/.github/workflows/netlify-cleanup-preview.yml
@@ -11,7 +11,7 @@ jobs:
       BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
       PR_NUMBER: ${{ github.event.number }}
     steps:
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Delete Neon Branch
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/netlify-deploy-preview.yml
+++ b/.github/workflows/netlify-deploy-preview.yml
@@ -14,20 +14,16 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     steps:
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v9
-
       - name: Create Neon Branch
         id: create-branch
-        uses: neondatabase/create-branch-action@v6
+        uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # 6.3.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: preview/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
+          branch_name: preview/pr-${{ github.event.number }}-${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@v1
+        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
 
       - name: Install Netlify CLI
         run: pnpm add -g netlify-cli
@@ -40,7 +36,7 @@ jobs:
         # functions are baked with `connectionString: undefined`, which makes
         # `node-postgres` fall back to PGHOST=localhost (127.0.0.1).
         env:
-          BRANCH: ${{ steps.branch-name.outputs.current_branch }}
+          BRANCH: ${{ github.head_ref }}
           DB_URL_POOLED: ${{ steps.create-branch.outputs.db_url_pooled }}
           DB_URL: ${{ steps.create-branch.outputs.db_url }}
         run: |
@@ -50,7 +46,7 @@ jobs:
       - name: Get branch preview URL
         id: branch-preview
         env:
-          BRANCH: ${{ steps.branch-name.outputs.current_branch }}
+          BRANCH: ${{ github.head_ref }}
         run: |
           SUBDOMAIN=$(curl -s -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID" | jq -r '.name')
@@ -86,7 +82,7 @@ jobs:
         # cheaply via `scripts/netlify-should-build.sh` (no branch DB env yet),
         # so this is the only build that actually runs.
         env:
-          BRANCH: ${{ steps.branch-name.outputs.current_branch }}
+          BRANCH: ${{ github.head_ref }}
         run: |
           curl -fsS -X POST \
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
@@ -112,9 +108,9 @@ jobs:
 
       - name: Comment on Pull Request
         if: success() && steps.find-comment.outputs.exists != 'true'
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          comment_tag: deploy-preview
+          comment-tag: deploy-preview
           message: |
             | Resource | Link |
             |----------|------|
@@ -124,17 +120,17 @@ jobs:
       - name: Remove failure comment on success
         if: success()
         continue-on-error: true
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          comment_tag: deploy-preview-failure
-          mode: delete
+          comment-tag: deploy-preview-failure
+          mode: delete-on-completion
           message: ''
 
       - name: Comment on failure
         if: failure()
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          comment_tag: deploy-preview-failure
+          comment-tag: deploy-preview-failure
           message: |
             ⚠️ **Branch preview setup failed**
 


### PR DESCRIPTION
## Summary

Response to the [TanStack npm supply-chain compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) (2026-05-11). Six commits, all CI/CD-only — no application code touched.

### What changed

- **SHA-pinned every third-party Action** to an immutable commit. A future namespace takeover on `chromaui`, `thollander`, `neondatabase`, `oven-sh`, or `complexdatacollective` can no longer publish a malicious update to a moving tag we trust. Also replaces `chromaui/action@latest` (the highest-risk reference in the repo before this PR) with a specific commit on v16.10.0.
- **Hardened `chromatic.yml`'s `issue_comment` trigger.** Added an `author_association` gate so only OWNER/MEMBER/COLLABORATOR comments can fire `/chromatic`; removed a dead `ref:` input from the Setup step that would have re-introduced an untrusted-code path if someone later "fixed" it; isolated the Chromatic pnpm-store cache via `cache-key-prefix` so a Chromatic-triggered run cannot poison the cache that `build.yml` restores on push to main.
- **Migrated `thollander/actions-comment-pull-request` v2 → v3** in `netlify-deploy-preview.yml`, including its breaking parameter renames (`comment_tag` → `comment-tag`) and `mode: delete` semantic change (now `delete-on-completion` to preserve v2's end-of-job-delete behaviour).
- **Removed `tj-actions/branch-names` entirely** — that namespace was the subject of the March 2024 `changed-files` compromise. We only used the action's `current_branch` output, which is `${{ github.head_ref }}` natively on `pull_request` events.
- **Bumped all first-party / Docker-official Actions** to their latest major versions. These are intentionally **not** SHA-pinned — verified-publisher namespaces (GitHub, Docker) are out of scope for SHA pinning per the project scope decision.
- **Scoped `id-token: write`** in `e2e.yml` and `cleanup-e2e-reports.yml` from workflow-level to job-level on only the jobs that consume OIDC. The `e2e` job, which runs untrusted PR code via `./scripts/run-e2e.sh`, no longer inherits the permission. Defense-in-depth — the OIDC token here is audience-bound to GitHub Pages, so the blast radius was already limited to Pages deployment.

### Explicitly NOT in this PR

- No `@tanstack/*` dependencies were touched — the repo only uses `@tanstack/react-table`, which is in the confirmed-clean `@tanstack/table` family per the postmortem.
- No SHA-pinning of first-party `actions/*` / `docker/*` actions.
- No fix for the pre-existing `/chromatic` feature bug where the workflow runs against main rather than the PR head — fixing it requires a separate product decision about whether the comment-trigger UX is worth the residual risk, and this PR removes the dead `ref:` input that would otherwise silently re-introduce the vulnerability if anyone "fixes" the bug.

### Plan & audit trail

`docs/superpowers/plans/2026-05-12-ci-hardening.md` (local-only; the `docs/superpowers/` path is gitignored).

## Test plan

- [ ] **`build.yml`** — passes automatically on this PR push.
- [ ] **`netlify-deploy-preview.yml`** — automatic on PR open. Verify:
  - Neon branch created successfully (PR comment appears with the Neon link).
  - Branch preview URL resolves.
  - The deploy-preview PR comment posts via the new thollander v3 path (exercises `comment-tag:` rename).
  - To exercise the failure / cleanup paths, temporarily break a setup script in a follow-up push: confirm failure comment appears, then on subsequent success the failure comment is deleted (exercises `mode: delete-on-completion`).
- [ ] **`/chromatic` from a maintainer** — comment `/chromatic` on this PR from a maintainer account. Confirm the workflow fires, Chromatic builds, the link comment appears, and the commit status is posted.
- [ ] **`/chromatic` from a non-maintainer** — high-value but optional. Have a non-collaborator account comment `/chromatic` (or open a second test PR from a fork). Confirm the workflow does **not** fire — Actions tab shows no run.
- [ ] **`e2e.yml`** — automatic on PR open. Verify the run completes through `deploy-report` and posts the PR comment with the new `actions/github-script@v9`.
- [ ] **`docker-publish.yml`** — triggers only on release. Either wait for the next release or push a test tag in a scratch repo to exercise the Docker v4/v7 + checkout v6 bumps.

## GitHub-UI checks not automatable

Open **Settings → Actions → General** and confirm:

- "Fork pull request workflows from outside collaborators": set to **Require approval for first-time contributors** or stricter.
- "Send write tokens to workflows from fork pull requests": **unchecked**.
- "Send secrets and variables to workflows from fork pull requests": **unchecked**.

If any of these are permissive, the chromatic hardening here is necessary but insufficient.

## Follow-ups (not blocking this PR)

- File an issue against [`complexdatacollective/github-actions`](https://github.com/complexdatacollective/github-actions) to bump the inner actions used by the `setup-pnpm` composite (`actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`, `pnpm/action-setup@v4` → `@v6`, `actions/cache@v4` → `@v5`).