### PR TITLE
feat(api): add protocols-meta endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
+        uses: complexdatacollective/github-actions/setup-pnpm@4d9ebee3e57834a7ac8389a57d0fe1ef3614be14 # v2
 
       - name: ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,7 +55,7 @@ jobs:
             ]);
 
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
+        uses: complexdatacollective/github-actions/setup-pnpm@4d9ebee3e57834a7ac8389a57d0fe1ef3614be14 # v2
         with:
           fetch-depth: '0'
           cache-key-prefix: chromatic-pnpm-store

--- a/.github/workflows/netlify-deploy-preview.yml
+++ b/.github/workflows/netlify-deploy-preview.yml
@@ -26,7 +26,12 @@ jobs:
         uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
 
       - name: Install Netlify CLI
-        run: pnpm add -g netlify-cli
+        # Install via npm rather than pnpm: pnpm 10+ resolves the global bin
+        # dir as `$PNPM_HOME/bin`, but `pnpm/action-setup` sets `PNPM_HOME` to
+        # `.../node_modules/.bin` (already a bin dir), so the resolved path
+        # `.bin/bin` is not on PATH and `pnpm add -g` errors out. npm's global
+        # bin is on PATH via actions/setup-node.
+        run: npm install -g netlify-cli
 
       - name: Set Netlify runtime environment variables
         # Set the database URLs on Netlify *before* anything else so that the

--- a/.github/workflows/netlify-deploy-preview.yml
+++ b/.github/workflows/netlify-deploy-preview.yml
@@ -23,15 +23,10 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Setup
-        uses: complexdatacollective/github-actions/setup-pnpm@93811ade40da19d041bcf2a55603b3c5992af246 # v1
+        uses: complexdatacollective/github-actions/setup-pnpm@4d9ebee3e57834a7ac8389a57d0fe1ef3614be14 # v2
 
       - name: Install Netlify CLI
-        # Install via npm rather than pnpm: pnpm 10+ resolves the global bin
-        # dir as `$PNPM_HOME/bin`, but `pnpm/action-setup` sets `PNPM_HOME` to
-        # `.../node_modules/.bin` (already a bin dir), so the resolved path
-        # `.bin/bin` is not on PATH and `pnpm add -g` errors out. npm's global
-        # bin is on PATH via actions/setup-node.
-        run: npm install -g netlify-cli
+        run: pnpm add -g netlify-cli
 
       - name: Set Netlify runtime environment variables
         # Set the database URLs on Netlify *before* anything else so that the

--- a/app/api/[version]/protocols-meta/route.ts
+++ b/app/api/[version]/protocols-meta/route.ts
@@ -52,9 +52,7 @@ async function v1(request: NextRequest) {
     return NextResponse.json(protocols, { headers: corsHeaders });
   } catch (e) {
     const error = ensureError(e);
-    captureException(error).catch(() => {
-      // swallow telemetry errors so they cannot replace the 500
-    });
+    await captureException(error);
     after(async () => {
       await shutdownPostHog();
     });

--- a/app/api/[version]/protocols-meta/route.ts
+++ b/app/api/[version]/protocols-meta/route.ts
@@ -19,23 +19,26 @@ export function OPTIONS() {
 }
 
 async function v1(request: NextRequest) {
-  const enabled = await getAppSetting('enableInterviewDataApi');
-  if (!enabled) {
-    return NextResponse.json(
-      { error: 'Interview Data API is not enabled' },
-      { status: 403, headers: corsHeaders },
-    );
-  }
-
-  const authResult = await requireApiTokenAuth(request);
-  if ('error' in authResult) {
-    return NextResponse.json(
-      { error: 'Authentication required. Provide a Bearer token.' },
-      { status: 401, headers: corsHeaders },
-    );
-  }
-
   try {
+    const enabled = await getAppSetting('enableInterviewDataApi');
+    if (!enabled) {
+      return NextResponse.json(
+        { error: 'Interview Data API is not enabled' },
+        { status: 403, headers: corsHeaders },
+      );
+    }
+
+    const authResult = await requireApiTokenAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json(
+        { error: 'Authentication required. Provide a Bearer token.' },
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'WWW-Authenticate': 'Bearer' },
+        },
+      );
+    }
+
     const protocols = await prisma.protocol.findMany({
       select: {
         id: true,
@@ -49,7 +52,9 @@ async function v1(request: NextRequest) {
     return NextResponse.json(protocols, { headers: corsHeaders });
   } catch (e) {
     const error = ensureError(e);
-    await captureException(error);
+    captureException(error).catch(() => {
+      // swallow telemetry errors so they cannot replace the 500
+    });
     after(async () => {
       await shutdownPostHog();
     });

--- a/app/api/[version]/protocols-meta/route.ts
+++ b/app/api/[version]/protocols-meta/route.ts
@@ -1,0 +1,68 @@
+import { after, type NextRequest, NextResponse } from 'next/server';
+import {
+  createCorsHeaders,
+  requireApiTokenAuth,
+} from '~/app/api/_helpers/auth';
+import { createVersionedHandler } from '~/app/api/_helpers/versioning';
+import { prisma } from '~/lib/db';
+import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { getAppSetting } from '~/queries/appSettings';
+import { ensureError } from '~/utils/ensureError';
+
+const corsHeaders = createCorsHeaders('GET, OPTIONS');
+
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: corsHeaders,
+  });
+}
+
+async function v1(request: NextRequest) {
+  const enabled = await getAppSetting('enableInterviewDataApi');
+  if (!enabled) {
+    return NextResponse.json(
+      { error: 'Interview Data API is not enabled' },
+      { status: 403, headers: corsHeaders },
+    );
+  }
+
+  const authResult = await requireApiTokenAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: 'Authentication required. Provide a Bearer token.' },
+      { status: 401, headers: corsHeaders },
+    );
+  }
+
+  try {
+    const protocols = await prisma.protocol.findMany({
+      select: {
+        id: true,
+        name: true,
+        importedAt: true,
+        lastModified: true,
+      },
+      orderBy: { importedAt: 'desc' },
+    });
+
+    return NextResponse.json(protocols, { headers: corsHeaders });
+  } catch (e) {
+    const error = ensureError(e);
+    await captureException(error);
+    after(async () => {
+      await shutdownPostHog();
+    });
+
+    return NextResponse.json(
+      { error: 'Failed to fetch protocols' },
+      { status: 500, headers: corsHeaders },
+    );
+  }
+}
+
+const handlers = {
+  v1: { GET: v1 },
+};
+
+export const GET = createVersionedHandler(handlers, 'GET');

--- a/lib/__tests__/posthog-server.test.ts
+++ b/lib/__tests__/posthog-server.test.ts
@@ -70,6 +70,17 @@ describe('posthog-server', () => {
         },
       });
     });
+
+    it('swallows errors thrown by underlying lookups', async () => {
+      mockGetDisableAnalytics.mockRejectedValue(new Error('db down'));
+
+      const { captureEvent } = await import('../posthog-server');
+
+      await expect(
+        captureEvent('test-event', { key: 'value' }),
+      ).resolves.toBeUndefined();
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
   });
 
   describe('captureException', () => {
@@ -95,6 +106,17 @@ describe('posthog-server', () => {
       expect(mockCaptureException).toHaveBeenCalledWith(error, 'install-123', {
         extra: 'data',
       });
+    });
+
+    it('swallows errors thrown by underlying lookups', async () => {
+      mockGetDisableAnalytics.mockRejectedValue(new Error('db down'));
+
+      const { captureException } = await import('../posthog-server');
+
+      await expect(
+        captureException(new Error('test'), { extra: 'data' }),
+      ).resolves.toBeUndefined();
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -34,33 +34,45 @@ export async function captureEvent(
   event: string,
   properties?: Record<string, unknown>,
 ) {
-  if (await isAnalyticsDisabled()) return;
+  // Telemetry must never throw — DB lookups for installationId/disableAnalytics
+  // can fail, and a failed capture should never break the calling flow.
+  try {
+    if (await isAnalyticsDisabled()) return;
 
-  const distinctId = await resolveInstallationId();
-  const client = getPostHogServer();
+    const distinctId = await resolveInstallationId();
+    const client = getPostHogServer();
 
-  client.capture({
-    distinctId,
-    event,
-    properties: {
-      app: POSTHOG_APP_NAME,
-      installation_id: distinctId,
-      ...properties,
-      $source: 'server',
-    },
-  });
+    client.capture({
+      distinctId,
+      event,
+      properties: {
+        app: POSTHOG_APP_NAME,
+        installation_id: distinctId,
+        ...properties,
+        $source: 'server',
+      },
+    });
+  } catch {
+    // swallow
+  }
 }
 
 export async function captureException(
   error: unknown,
   properties?: Record<string, unknown>,
 ) {
-  if (await isAnalyticsDisabled()) return;
+  // Telemetry must never throw — DB lookups for installationId/disableAnalytics
+  // can fail, and a failed capture should never replace the original error.
+  try {
+    if (await isAnalyticsDisabled()) return;
 
-  const distinctId = await resolveInstallationId();
-  const client = getPostHogServer();
+    const distinctId = await resolveInstallationId();
+    const client = getPostHogServer();
 
-  client.captureException(error, distinctId, properties);
+    client.captureException(error, distinctId, properties);
+  } catch {
+    // swallow
+  }
 }
 
 export async function shutdownPostHog() {


### PR DESCRIPTION
Returns [{id, name, importedAt, lastModified}] so external scripts can get protocol ids for constructing onboarding urls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned API endpoint for retrieving protocol metadata
  * Includes Bearer token authentication requirement
  * Supports CORS cross-origin requests
  * Returns protocol records with metadata including ID, name, and timestamps
  * Implements feature flag validation and comprehensive error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/Fresco/pull/752)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->