### PR TITLE
Migrate pnpm configuration to workspace format and upgrade to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-auto-install-peers=true
-public-hoist-pattern[]=*tailwind-config*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ styles/                # Global CSS/SCSS
 - **Styling**: Tailwind CSS 4.1 + shadcn/ui
 - **State Management**: Redux Toolkit (interview sessions)
 - **Forms**: React Hook Form + Zod validation
-- **Package Manager**: pnpm 9.1.1
+- **Package Manager**: pnpm 11
 
 ## Code Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ styles/                # Global CSS/SCSS
 - **Styling**: Tailwind CSS 4.1 + shadcn/ui
 - **State Management**: Redux Toolkit (interview sessions)
 - **Forms**: React Hook Form + Zod validation
-- **Package Manager**: pnpm 11
+- **Package Manager**: pnpm 11.1.2
 
 ## Code Conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN corepack enable
 
 # Copy dependency files
-COPY package.json pnpm-lock.yaml* prisma.config.ts env.js ./
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml prisma.config.ts env.js ./
 COPY lib/db/schema.prisma ./lib/db/schema.prisma
 COPY patches ./patches
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "scripts": {
     "build": "next build",
     "build:platform": "prisma generate && tsx ./scripts/setup-database.ts && tsx ./scripts/initialize.ts && next build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "build": "next build",
     "build:platform": "prisma generate && tsx ./scripts/setup-database.ts && tsx ./scripts/initialize.ts && next build",
@@ -23,21 +23,6 @@
     "build-storybook": "SKIP_ENV_VALIDATION=true storybook build",
     "chromatic": "SKIP_ENV_VALIDATION=true pnpx chromatic --exit-zero-on-changes --project-token=chpt_be05032bf2520b5",
     "docker-build": "docker build -t fresco:latest ."
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@prisma/engines",
-      "@tailwindcss/oxide",
-      "core-js-pure",
-      "esbuild",
-      "prisma",
-      "sharp",
-      "unrs-resolver"
-    ],
-    "patchedDependencies": {
-      "react-best-merge-refs@1.0.2": "patches/react-best-merge-refs@1.0.2.patch"
-    }
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1047.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,21 @@
+autoInstallPeers: true
+
+publicHoistPattern:
+  - '*tailwind-config*'
+
+allowBuilds:
+  '@parcel/watcher': true
+  '@posthog/cli': false
+  '@prisma/engines': true
+  '@tailwindcss/oxide': true
+  core-js: false
+  core-js-pure: true
+  esbuild: true
+  msgpackr-extract: false
+  prisma: true
+  protobufjs: false
+  sharp: true
+  unrs-resolver: true
+
+patchedDependencies:
+  react-best-merge-refs@1.0.2: patches/react-best-merge-refs@1.0.2.patch


### PR DESCRIPTION
## Summary

Migrates the project's pnpm configuration from package.json to a dedicated `pnpm-workspace.yaml` file and upgrades pnpm from v10.33.0 to v11.1.2. This modernizes the monorepo setup and aligns with pnpm's recommended configuration approach.

## Key Changes

- **Created `pnpm-workspace.yaml`**: Extracted pnpm-specific configuration from `package.json` into a dedicated workspace configuration file with:
  - `autoInstallPeers: true` (moved from `.npmrc`)
  - `publicHoistPattern` for tailwind-config packages (moved from `.npmrc`)
  - `allowBuilds` configuration (replaces `onlyBuiltDependencies` with inverted logic for packages that should NOT build)
  - `patchedDependencies` for react-best-merge-refs patch

- **Updated `package.json`**: 
  - Removed `pnpm` configuration object (now in workspace config)
  - Upgraded `packageManager` from pnpm@10.33.0 to pnpm@11.1.2
  - Removed `.npmrc` configuration (now in workspace config)

- **Removed `.npmrc`**: Configuration migrated to `pnpm-workspace.yaml`

- **Updated documentation**: 
  - `CLAUDE.md`: Updated package manager version from pnpm 9.1.1 to pnpm 11
  - `Dockerfile`: Added `pnpm-workspace.yaml` to COPY command for proper workspace setup

## Implementation Details

The migration uses pnpm's `allowBuilds` configuration (inverse of the previous `onlyBuiltDependencies`) to explicitly control which native dependencies should be built. This provides clearer intent and better aligns with pnpm v11's configuration model.

https://claude.ai/code/session_01DQ1xSVNK68LLoJcrCoDdTs