### PR TITLE
fix(import): make large protocol uploads reliable + import UX

### DIFF
--- a/actions/protocols.ts
+++ b/actions/protocols.ts
@@ -9,6 +9,7 @@ import { Prisma } from '~/lib/db/generated/client';
 import { hashProtocol } from '@codaco/protocol-validation';
 import { getStorageLayer } from '~/lib/storage/layers/StorageLayer';
 import { AssetStorage } from '~/lib/storage/services/AssetStorage';
+import { selectUnreferencedKeys } from '~/lib/protocol/selectUnreferencedKeys';
 import { type protocolInsertSchema } from '~/schemas/protocol';
 import { addEvent } from './activityFeed';
 
@@ -143,6 +144,53 @@ export async function deleteProtocols(hashes: string[]) {
   }
 }
 
+/**
+ * Best-effort cleanup of storage blobs that were uploaded during a protocol
+ * import that ultimately failed. Any key still referenced by a stored asset or
+ * protocol original file is skipped, so blobs in use by other protocols are
+ * never deleted. Never throws — cleanup failures must not mask the import error.
+ */
+export async function cleanupUploadedFiles(keys: string[]) {
+  await requireApiAuth();
+
+  const uploadedKeys = keys.filter((key) => key.length > 0);
+  if (uploadedKeys.length === 0) {
+    return { error: null, deletedCount: 0 };
+  }
+
+  try {
+    const [referencedAssets, referencingProtocols] = await Promise.all([
+      prisma.asset.findMany({
+        where: { key: { in: uploadedKeys } },
+        select: { key: true },
+      }),
+      prisma.protocol.findMany({
+        where: { originalFileKey: { in: uploadedKeys } },
+        select: { originalFileKey: true },
+      }),
+    ]);
+
+    const referencedKeys = [
+      ...referencedAssets.map((asset) => asset.key),
+      ...referencingProtocols
+        .map((protocol) => protocol.originalFileKey)
+        .filter((key): key is string => key !== null),
+    ];
+
+    const keysToDelete = selectUnreferencedKeys(uploadedKeys, referencedKeys);
+
+    if (keysToDelete.length > 0) {
+      await deleteFilesFromStorage(keysToDelete);
+    }
+
+    return { error: null, deletedCount: keysToDelete.length };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log('Error cleaning up uploaded files after failed import:', error);
+    return { error: 'Failed to clean up uploaded files', deletedCount: 0 };
+  }
+}
+
 async function deleteFilesFromStorage(fileKey: string | string[]) {
   await requireApiAuth();
 
@@ -202,12 +250,10 @@ export async function insertProtocol(
 
     return { error: null, success: true };
   } catch (e) {
-    // Attempt to delete any files we uploaded to storage (assets + original)
-    const keysToCleanUp = [
-      ...newAssets.map((a: { key: string }) => a.key),
-      originalFile.key,
-    ];
-    void deleteFilesFromStorage(keysToCleanUp);
+    // Storage cleanup of any uploaded blobs is handled by the import caller
+    // (processJob) via cleanupUploadedFiles, which runs for every failure path
+    // and skips keys still referenced by other protocols.
+
     // Check for protocol already existing
     if (e instanceof Prisma.PrismaClientKnownRequestError) {
       if (e.code === 'P2002') {

--- a/components/ProtocolImport/ImportToastContent.stories.tsx
+++ b/components/ProtocolImport/ImportToastContent.stories.tsx
@@ -30,35 +30,42 @@ export const Parsing: Story = {
 export const Validating: Story = {
   args: {
     phase: 'validating',
-    progress: 16.7,
+    progress: 14.3,
   },
 };
 
 export const CheckingDuplicates: Story = {
   args: {
     phase: 'checking-duplicates',
-    progress: 33.3,
+    progress: 28.6,
   },
 };
 
 export const ExtractingAssets: Story = {
   args: {
     phase: 'extracting-assets',
-    progress: 50,
+    progress: 42.9,
+  },
+};
+
+export const UploadingProtocol: Story = {
+  args: {
+    phase: 'uploading-protocol',
+    progress: 64,
   },
 };
 
 export const UploadingAssets: Story = {
   args: {
     phase: 'uploading-assets',
-    progress: 75,
+    progress: 78,
   },
 };
 
 export const Saving: Story = {
   args: {
     phase: 'saving',
-    progress: 83.3,
+    progress: 85.7,
   },
 };
 

--- a/components/ProtocolImport/ImportToastContent.tsx
+++ b/components/ProtocolImport/ImportToastContent.tsx
@@ -3,6 +3,7 @@
 import {
   Database,
   FileSearch,
+  FileUp,
   Package,
   RefreshCw,
   Search,
@@ -23,6 +24,7 @@ const phaseConfig: Record<ImportPhase, PhaseConfig> = {
   'validating': { label: 'Validating...', icon: ShieldCheck },
   'checking-duplicates': { label: 'Checking duplicates...', icon: Search },
   'extracting-assets': { label: 'Extracting assets...', icon: Package },
+  'uploading-protocol': { label: 'Uploading protocol...', icon: FileUp },
   'uploading-assets': { label: 'Uploading assets...', icon: Upload },
   'saving': { label: 'Saving...', icon: Database },
   'complete': { label: 'Import complete', icon: Database },
@@ -76,11 +78,14 @@ export default function ImportToastContent({
         <Icon className="size-3.5 animate-pulse" />
         <span>{config.label}</span>
       </div>
-      <ProgressBar
-        percentProgress={progress}
-        orientation="horizontal"
-        nudge={false}
-      />
+      <div className="flex items-center gap-2">
+        <ProgressBar
+          percentProgress={progress}
+          orientation="horizontal"
+          nudge={false}
+        />
+        <span className="text-xs tabular-nums">{Math.round(progress)}%</span>
+      </div>
     </div>
   );
 }

--- a/components/ProtocolImport/__tests__/calculateImportProgress.test.ts
+++ b/components/ProtocolImport/__tests__/calculateImportProgress.test.ts
@@ -2,57 +2,63 @@ import { describe, expect, it } from 'vitest';
 import { calculateImportProgress } from '../calculateImportProgress';
 
 describe('calculateImportProgress', () => {
-  const PHASE_SIZE = 100 / 6;
+  const PHASE_SIZE = 100 / 7;
 
   it('returns 0 for parsing phase', () => {
     expect(calculateImportProgress('parsing')).toBe(0);
   });
 
-  it('returns 1/6 for validating phase', () => {
+  it('returns 1/7 for validating phase', () => {
     expect(calculateImportProgress('validating')).toBeCloseTo(PHASE_SIZE);
   });
 
-  it('returns 2/6 for checking-duplicates phase', () => {
+  it('returns 2/7 for checking-duplicates phase', () => {
     expect(calculateImportProgress('checking-duplicates')).toBeCloseTo(
       PHASE_SIZE * 2,
     );
   });
 
-  it('returns 3/6 for extracting-assets phase', () => {
+  it('returns 3/7 for extracting-assets phase', () => {
     expect(calculateImportProgress('extracting-assets')).toBeCloseTo(
       PHASE_SIZE * 3,
     );
   });
 
-  it('returns 4/6 base for uploading-assets with 0% progress', () => {
-    expect(calculateImportProgress('uploading-assets', 0)).toBeCloseTo(
+  it('subdivides uploading-protocol by phase progress', () => {
+    expect(calculateImportProgress('uploading-protocol', 0)).toBeCloseTo(
       PHASE_SIZE * 4,
     );
-  });
-
-  it('returns midpoint for uploading-assets with 50% progress', () => {
-    expect(calculateImportProgress('uploading-assets', 50)).toBeCloseTo(
+    expect(calculateImportProgress('uploading-protocol', 50)).toBeCloseTo(
       PHASE_SIZE * 4 + PHASE_SIZE * 0.5,
+    );
+    expect(calculateImportProgress('uploading-protocol', 100)).toBeCloseTo(
+      PHASE_SIZE * 5,
     );
   });
 
-  it('returns end of segment for uploading-assets with 100% progress', () => {
-    expect(calculateImportProgress('uploading-assets', 100)).toBeCloseTo(
+  it('subdivides uploading-assets by phase progress', () => {
+    expect(calculateImportProgress('uploading-assets', 0)).toBeCloseTo(
       PHASE_SIZE * 5,
+    );
+    expect(calculateImportProgress('uploading-assets', 50)).toBeCloseTo(
+      PHASE_SIZE * 5 + PHASE_SIZE * 0.5,
+    );
+    expect(calculateImportProgress('uploading-assets', 100)).toBeCloseTo(
+      PHASE_SIZE * 6,
     );
   });
 
   it('clamps uploading-assets progress to 0-100', () => {
     expect(calculateImportProgress('uploading-assets', -10)).toBeCloseTo(
-      PHASE_SIZE * 4,
+      PHASE_SIZE * 5,
     );
     expect(calculateImportProgress('uploading-assets', 150)).toBeCloseTo(
-      PHASE_SIZE * 5,
+      PHASE_SIZE * 6,
     );
   });
 
-  it('returns 5/6 for saving phase', () => {
-    expect(calculateImportProgress('saving')).toBeCloseTo(PHASE_SIZE * 5);
+  it('returns 6/7 for saving phase', () => {
+    expect(calculateImportProgress('saving')).toBeCloseTo(PHASE_SIZE * 6);
   });
 
   it('returns 100 for complete phase', () => {

--- a/components/ProtocolImport/calculateImportProgress.ts
+++ b/components/ProtocolImport/calculateImportProgress.ts
@@ -3,6 +3,7 @@ export type ImportPhase =
   | 'validating'
   | 'checking-duplicates'
   | 'extracting-assets'
+  | 'uploading-protocol'
   | 'uploading-assets'
   | 'saving'
   | 'complete'
@@ -13,6 +14,7 @@ const PHASES: ImportPhase[] = [
   'validating',
   'checking-duplicates',
   'extracting-assets',
+  'uploading-protocol',
   'uploading-assets',
   'saving',
 ];
@@ -20,11 +22,16 @@ const PHASES: ImportPhase[] = [
 const PHASE_COUNT = PHASES.length;
 const PHASE_SIZE = 100 / PHASE_COUNT;
 
+const SUBDIVIDED_PHASES: ImportPhase[] = [
+  'uploading-protocol',
+  'uploading-assets',
+];
+
 /**
  * Calculates overall import progress (0-100) from a phase and optional
- * sub-phase progress. Each of the 6 processing phases gets an equal 1/6
- * segment. For `uploading-assets`, `phaseProgress` (0-100) subdivides
- * that segment. Other phases snap to their start percentage on entry.
+ * sub-phase progress. Each of the 7 processing phases gets an equal 1/7
+ * segment. For the upload phases, `phaseProgress` (0-100) subdivides that
+ * segment. Other phases snap to their start percentage on entry.
  */
 export function calculateImportProgress(
   phase: ImportPhase,
@@ -38,7 +45,7 @@ export function calculateImportProgress(
 
   const base = phaseIndex * PHASE_SIZE;
 
-  if (phase === 'uploading-assets') {
+  if (SUBDIVIDED_PHASES.includes(phase)) {
     const clampedProgress = Math.min(Math.max(phaseProgress, 0), 100);
     return base + (clampedProgress / 100) * PHASE_SIZE;
   }

--- a/fresco.config.ts
+++ b/fresco.config.ts
@@ -9,3 +9,8 @@ export const POSTHOG_API_KEY =
 
 // If unconfigured, the app will shut down after 2 hours (7200000 ms)
 export const UNCONFIGURED_TIMEOUT = 7200000;
+
+// Maximum size of a .netcanvas protocol file that can be imported.
+// This matches the UploadThing per-file limit (256MB) and is enforced
+// regardless of storage provider to keep messaging consistent.
+export const MAX_PROTOCOL_UPLOAD_BYTES = 256 * 1024 * 1024;

--- a/hooks/useProtocolImport.tsx
+++ b/hooks/useProtocolImport.tsx
@@ -223,21 +223,29 @@ export const useProtocolImport = () => {
         throw new Error('Error checking for existing assets');
       }
 
-      // Phase: Uploading assets
-      updateToastPhase(toastId, 'uploading-assets');
+      // Phase: Uploading protocol
+      updateToastPhase(toastId, 'uploading-protocol');
 
-      const filesToUpload = [...newAssets.map((asset) => asset.file), file];
-
-      const uploadedFiles = await uploadAssets(filesToUpload, (progress) => {
-        updateToastPhase(toastId, 'uploading-assets', progress);
+      const [uploadedOriginalFile] = await uploadAssets([file], (progress) => {
+        updateToastPhase(toastId, 'uploading-protocol', progress);
       });
 
-      const uploadedOriginalFile = uploadedFiles.at(-1);
       if (uploadedOriginalFile?.name !== file.name) {
         throw new Error('Original protocol file upload result mismatch');
       }
 
-      const uploadedAssetFiles = uploadedFiles.slice(0, newAssets.length);
+      // Phase: Uploading assets
+      updateToastPhase(toastId, 'uploading-assets');
+
+      const uploadedAssetFiles = newAssets.length
+        ? await uploadAssets(
+            newAssets.map((asset) => asset.file),
+            (progress) => {
+              updateToastPhase(toastId, 'uploading-assets', progress);
+            },
+          )
+        : [];
+
       newAssetsWithCombinedMetadata = newAssets.map((asset) => {
         const uploadedAsset = uploadedAssetFiles.find(
           (uploadedFile) => uploadedFile.name === asset.name,

--- a/hooks/useProtocolImport.tsx
+++ b/hooks/useProtocolImport.tsx
@@ -9,6 +9,7 @@ import { queue } from 'async';
 import posthog from 'posthog-js';
 import { useCallback, useRef } from 'react';
 import {
+  cleanupUploadedFiles,
   getNewAssetIds,
   getProtocolByHash,
   insertProtocol,
@@ -135,6 +136,10 @@ export const useProtocolImport = () => {
       importProtocols([file]);
     };
 
+    // Storage keys of every blob uploaded during this attempt, so they can be
+    // cleaned up on a best-effort basis if the import fails partway through.
+    const uploadedKeys: string[] = [];
+
     try {
       // Phase: Parsing
       updateToastPhase(toastId, 'parsing');
@@ -234,6 +239,10 @@ export const useProtocolImport = () => {
         updateToastPhase(toastId, 'uploading-protocol', progress);
       });
 
+      if (uploadedOriginalFile) {
+        uploadedKeys.push(uploadedOriginalFile.key);
+      }
+
       if (uploadedOriginalFile?.name !== file.name) {
         throw new Error('Original protocol file upload result mismatch');
       }
@@ -249,6 +258,10 @@ export const useProtocolImport = () => {
             },
           )
         : [];
+
+      uploadedKeys.push(
+        ...uploadedAssetFiles.map((uploadedFile) => uploadedFile.key),
+      );
 
       newAssetsWithCombinedMetadata = newAssets.map((asset) => {
         const uploadedAsset = uploadedAssetFiles.find(
@@ -298,6 +311,12 @@ export const useProtocolImport = () => {
       const error = ensureError(e);
 
       posthog.captureException(error);
+
+      // Best-effort cleanup of any blobs uploaded before the failure, so a
+      // failed import doesn't leave orphaned files in storage.
+      if (uploadedKeys.length > 0) {
+        void cleanupUploadedFiles(uploadedKeys);
+      }
 
       updateToastPhase(toastId, 'error', 0, error.message, retryThisFile);
 

--- a/hooks/useProtocolImport.tsx
+++ b/hooks/useProtocolImport.tsx
@@ -25,7 +25,9 @@ import {
   type ProtocolValidationError,
 } from '~/lib/protocol/validateAndMigrateProtocol';
 import { useUploadAssets } from '~/hooks/useUploadAssets';
+import Spinner from '@codaco/fresco-ui/Spinner';
 import { type AssetInsertType } from '~/schemas/protocol';
+import { getProtocolSizeError } from '~/utils/protocolSize';
 import { DatabaseError } from '~/utils/databaseError';
 import { ensureError } from '~/utils/ensureError';
 import {
@@ -92,6 +94,7 @@ export const useProtocolImport = () => {
         variant: 'success',
         title: 'Protocol imported successfully',
         description: `Protocol ${toastId} has been imported.`,
+        icon: null,
         timeout: 2000,
       });
       return;
@@ -100,6 +103,7 @@ export const useProtocolImport = () => {
     if (phase === 'error') {
       toastUpdate(toastId, {
         variant: 'destructive',
+        icon: null,
         description: (
           <ImportToastContent
             phase={phase}
@@ -307,6 +311,18 @@ export const useProtocolImport = () => {
 
   const importProtocols = useCallback((files: File[]) => {
     files.forEach((file) => {
+      const sizeError = getProtocolSizeError(file);
+      if (sizeError) {
+        toastRef.current.add({
+          id: generateJobId(),
+          variant: 'destructive',
+          title: file.name,
+          description: sizeError,
+          timeout: 0,
+        });
+        return;
+      }
+
       const jobAlreadyExists = activeJobs.current.has(file.name);
 
       if (jobAlreadyExists) {
@@ -322,6 +338,7 @@ export const useProtocolImport = () => {
         id: toastId,
         title: file.name,
         description: <ImportToastContent phase="parsing" progress={0} />,
+        icon: <Spinner size="xs" />,
         timeout: 0,
       });
 

--- a/hooks/useUploadAssets.ts
+++ b/hooks/useUploadAssets.ts
@@ -2,14 +2,10 @@
 
 import { useCallback } from 'react';
 import type { PresignedUploadUrl } from '~/lib/storage/services/AssetStorage';
-import { uploadFiles } from '~/lib/uploadthing/client-helpers';
-
-type UploadedFile = {
-  key: string;
-  url: string;
-  name: string;
-  size: number;
-};
+import {
+  type UploadedFile,
+  uploadToUploadThingWithRetry,
+} from '~/lib/uploadthing/uploadWithRetry';
 
 type PresignResponse =
   | { provider: 's3'; urls: PresignedUploadUrl[] }
@@ -102,19 +98,7 @@ async function uploadViaUploadThing(
   files: File[],
   onProgress?: (progress: number) => void,
 ): Promise<UploadedFile[]> {
-  const results = await uploadFiles('assetRouter', {
-    files,
-    onUploadProgress: ({ progress }) => {
-      if (onProgress) onProgress(progress);
-    },
-  });
-
-  return results.map((result) => ({
-    key: result.key,
-    url: result.ufsUrl,
-    name: result.name,
-    size: result.size,
-  }));
+  return uploadToUploadThingWithRetry(files, onProgress);
 }
 
 export function useUploadAssets() {

--- a/lib/protocol/__tests__/selectUnreferencedKeys.test.ts
+++ b/lib/protocol/__tests__/selectUnreferencedKeys.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { selectUnreferencedKeys } from '~/lib/protocol/selectUnreferencedKeys';
+
+describe('selectUnreferencedKeys', () => {
+  it('returns all keys when none are referenced', () => {
+    expect(selectUnreferencedKeys(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+
+  it('excludes keys referenced by existing assets or protocols', () => {
+    expect(selectUnreferencedKeys(['a', 'b', 'c'], ['b'])).toEqual(['a', 'c']);
+  });
+
+  it('de-duplicates repeated keys', () => {
+    expect(selectUnreferencedKeys(['a', 'a', 'b'], [])).toEqual(['a', 'b']);
+  });
+
+  it('drops empty keys', () => {
+    expect(selectUnreferencedKeys(['', 'a', ''], [])).toEqual(['a']);
+  });
+
+  it('returns an empty array when every key is referenced', () => {
+    expect(selectUnreferencedKeys(['a', 'b'], ['a', 'b'])).toEqual([]);
+  });
+});

--- a/lib/protocol/selectUnreferencedKeys.ts
+++ b/lib/protocol/selectUnreferencedKeys.ts
@@ -1,0 +1,24 @@
+/**
+ * From a set of storage keys uploaded during an import, returns those that are
+ * safe to delete after a failure: de-duplicated, non-empty, and not present in
+ * `referencedKeys`. `referencedKeys` are the keys still in use by existing
+ * assets or protocols, so blobs belonging to other protocols are never removed.
+ */
+export function selectUnreferencedKeys(
+  uploadedKeys: string[],
+  referencedKeys: Iterable<string>,
+): string[] {
+  const referenced = new Set(referencedKeys);
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const key of uploadedKeys) {
+    if (key.length === 0 || seen.has(key) || referenced.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(key);
+  }
+
+  return result;
+}

--- a/lib/uploadthing/__tests__/uploadWithRetry.test.ts
+++ b/lib/uploadthing/__tests__/uploadWithRetry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type UploadedFile,
+  uploadToUploadThingWithRetry,
+} from '~/lib/uploadthing/uploadWithRetry';
+
+const uploadedFiles: UploadedFile[] = [
+  { key: 'key-1', url: 'https://ut/key-1', name: 'p.netcanvas', size: 10 },
+];
+
+const file = new File(['x'], 'p.netcanvas');
+const NO_BACKOFF = [0, 0, 0];
+
+describe('uploadToUploadThingWithRetry', () => {
+  it('returns mapped files on first success', async () => {
+    const startUpload = vi.fn().mockResolvedValue({
+      done: () => Promise.resolve(uploadedFiles),
+    });
+
+    const result = await uploadToUploadThingWithRetry([file], undefined, {
+      backoffMs: NO_BACKOFF,
+      startUpload,
+    });
+
+    expect(result).toEqual(uploadedFiles);
+    expect(startUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a failed attempt then succeeds', async () => {
+    const startUpload = vi
+      .fn()
+      .mockResolvedValueOnce({
+        done: () => Promise.reject(new Error('XHR failed 400')),
+      })
+      .mockResolvedValueOnce({ done: () => Promise.resolve(uploadedFiles) });
+
+    const result = await uploadToUploadThingWithRetry([file], undefined, {
+      backoffMs: NO_BACKOFF,
+      startUpload,
+    });
+
+    expect(result).toEqual(uploadedFiles);
+    expect(startUpload).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws the last error after exhausting all attempts', async () => {
+    const startUpload = vi.fn().mockResolvedValue({
+      done: () => Promise.reject(new Error('XHR failed 400')),
+    });
+
+    await expect(
+      uploadToUploadThingWithRetry([file], undefined, {
+        backoffMs: NO_BACKOFF,
+        startUpload,
+      }),
+    ).rejects.toThrow('XHR failed 400');
+    expect(startUpload).toHaveBeenCalledTimes(3);
+  });
+
+  it('forwards aggregate progress', async () => {
+    const startUpload = vi.fn(
+      (_files: File[], onProgress: (p: number) => void) => {
+        onProgress(42);
+        return Promise.resolve({
+          done: () => Promise.resolve(uploadedFiles),
+        });
+      },
+    );
+    const onProgress = vi.fn();
+
+    await uploadToUploadThingWithRetry([file], onProgress, {
+      backoffMs: NO_BACKOFF,
+      startUpload,
+    });
+
+    expect(onProgress).toHaveBeenCalledWith(42);
+  });
+});

--- a/lib/uploadthing/client-helpers.ts
+++ b/lib/uploadthing/client-helpers.ts
@@ -1,4 +1,4 @@
 import { genUploader } from 'uploadthing/client';
 import type { OurFileRouter } from '~/app/api/uploadthing/core';
 
-export const { uploadFiles } = genUploader<OurFileRouter>();
+export const { uploadFiles, createUpload } = genUploader<OurFileRouter>();

--- a/lib/uploadthing/client-helpers.ts
+++ b/lib/uploadthing/client-helpers.ts
@@ -1,4 +1,4 @@
 import { genUploader } from 'uploadthing/client';
 import type { OurFileRouter } from '~/app/api/uploadthing/core';
 
-export const { uploadFiles, createUpload } = genUploader<OurFileRouter>();
+export const { createUpload } = genUploader<OurFileRouter>();

--- a/lib/uploadthing/uploadWithRetry.ts
+++ b/lib/uploadthing/uploadWithRetry.ts
@@ -1,0 +1,81 @@
+import { createUpload } from '~/lib/uploadthing/client-helpers';
+import { ensureError } from '~/utils/ensureError';
+
+export type UploadedFile = {
+  key: string;
+  url: string;
+  name: string;
+  size: number;
+};
+
+type AssetUploadHandle = {
+  done: () => Promise<UploadedFile[]>;
+};
+
+type StartAssetUpload = (
+  files: File[],
+  onProgress: (totalProgress: number) => void,
+) => Promise<AssetUploadHandle>;
+
+// Delay (ms) applied before attempt index N. Index 0 (first attempt) never
+// waits. Length determines the number of attempts.
+const DEFAULT_BACKOFF_MS = [0, 2000, 5000];
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Default uploader: drives UploadThing's resumable `createUpload` and maps the
+// SDK result to the app's `UploadedFile` shape. `createUpload`'s
+// `onUploadProgress` reports `totalProgress` (overall bytes across the batch),
+// which avoids the per-file progress overwrites that made the bar jump.
+const startAssetUpload: StartAssetUpload = async (files, onProgress) => {
+  const { done } = await createUpload('assetRouter', {
+    files,
+    onUploadProgress: ({ totalProgress }) => onProgress(totalProgress),
+  });
+
+  return {
+    done: async () => {
+      const results = await done();
+      return results.map((result) => ({
+        key: result.key,
+        url: result.ufsUrl,
+        name: result.name,
+        size: result.size,
+      }));
+    },
+  };
+};
+
+/**
+ * Uploads files to UploadThing via the resumable `createUpload` API, retrying
+ * the whole upload on failure. UploadThing's single-PUT upload has no built-in
+ * retry, so a transient ingest rejection (observed as `XHR failed 400` on large
+ * files) would otherwise abort the import permanently.
+ */
+export async function uploadToUploadThingWithRetry(
+  files: File[],
+  onProgress?: (progress: number) => void,
+  options: { backoffMs?: number[]; startUpload?: StartAssetUpload } = {},
+): Promise<UploadedFile[]> {
+  const backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const startUpload = options.startUpload ?? startAssetUpload;
+  let lastError: Error = new Error('Upload failed');
+
+  for (let attempt = 0; attempt < backoffMs.length; attempt++) {
+    const delay = backoffMs[attempt] ?? 0;
+    if (attempt > 0 && delay > 0) {
+      await wait(delay);
+    }
+
+    try {
+      const { done } = await startUpload(files, (progress) =>
+        onProgress?.(progress),
+      );
+      return await done();
+    } catch (error) {
+      lastError = ensureError(error);
+    }
+  }
+
+  throw lastError;
+}

--- a/utils/__tests__/protocolSize.test.ts
+++ b/utils/__tests__/protocolSize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getProtocolSizeError } from '~/utils/protocolSize';
+
+describe('getProtocolSizeError', () => {
+  it('returns null for a file at the limit', () => {
+    expect(getProtocolSizeError({ size: 256 * 1024 * 1024 })).toBeNull();
+  });
+
+  it('returns null for a small file', () => {
+    expect(getProtocolSizeError({ size: 1024 })).toBeNull();
+  });
+
+  it('returns a message for an oversized file', () => {
+    const error = getProtocolSizeError({
+      size: 300 * 1024 * 1024,
+    });
+    expect(error).toContain('300');
+    expect(error).toContain('256');
+  });
+});

--- a/utils/__tests__/protocolSize.test.ts
+++ b/utils/__tests__/protocolSize.test.ts
@@ -17,4 +17,15 @@ describe('getProtocolSizeError', () => {
     expect(error).toContain('300');
     expect(error).toContain('256');
   });
+
+  it('rejects a file just over the limit and rounds its size up', () => {
+    const error = getProtocolSizeError({ size: 256 * 1024 * 1024 + 1 });
+    // Math.ceil avoids displaying an over-limit file as exactly "256 MB".
+    expect(error).toContain('257');
+  });
+
+  it('phrases the limit inclusively to match the <= check', () => {
+    const error = getProtocolSizeError({ size: 300 * 1024 * 1024 });
+    expect(error).toContain('256 MB or smaller');
+  });
 });

--- a/utils/protocolSize.ts
+++ b/utils/protocolSize.ts
@@ -1,0 +1,17 @@
+import { MAX_PROTOCOL_UPLOAD_BYTES } from '~/fresco.config';
+
+function formatMegabytes(bytes: number): number {
+  return Math.round(bytes / (1024 * 1024));
+}
+
+/**
+ * Returns a human-readable error if the protocol file exceeds the upload
+ * limit, or null if it is acceptable.
+ */
+export function getProtocolSizeError(file: { size: number }): string | null {
+  if (file.size <= MAX_PROTOCOL_UPLOAD_BYTES) {
+    return null;
+  }
+
+  return `This protocol is ${formatMegabytes(file.size)} MB. Protocols must be smaller than ${formatMegabytes(MAX_PROTOCOL_UPLOAD_BYTES)} MB to import.`;
+}

--- a/utils/protocolSize.ts
+++ b/utils/protocolSize.ts
@@ -1,17 +1,20 @@
 import { MAX_PROTOCOL_UPLOAD_BYTES } from '~/fresco.config';
 
+// Round up so a file that is only slightly over the limit is never displayed
+// as exactly the limit (which would read as contradicting the message).
 function formatMegabytes(bytes: number): number {
-  return Math.round(bytes / (1024 * 1024));
+  return Math.ceil(bytes / (1024 * 1024));
 }
 
 /**
  * Returns a human-readable error if the protocol file exceeds the upload
- * limit, or null if it is acceptable.
+ * limit, or null if it is acceptable. The limit is inclusive (a file exactly
+ * at the limit is allowed), which the message wording reflects.
  */
 export function getProtocolSizeError(file: { size: number }): string | null {
   if (file.size <= MAX_PROTOCOL_UPLOAD_BYTES) {
     return null;
   }
 
-  return `This protocol is ${formatMegabytes(file.size)} MB. Protocols must be smaller than ${formatMegabytes(MAX_PROTOCOL_UPLOAD_BYTES)} MB to import.`;
+  return `This protocol is ${formatMegabytes(file.size)} MB. Protocols must be ${formatMegabytes(MAX_PROTOCOL_UPLOAD_BYTES)} MB or smaller to import.`;
 }


### PR DESCRIPTION
## Summary

Fixes intermittent failures when importing large (~200 MB+) `.netcanvas` protocols, which started with the "download protocol" feature (the full `.netcanvas` is now uploaded).

**Root cause (confirmed via HAR forensics):** UploadThing's stable `uploadFiles` sends the whole file as a single PUT with **zero retry**. The 207 MB `.netcanvas` is a ~150 s single request that intermittently trips an early ingest rejection (`XHR failed 400`, returned mid-upload — visible as `wait≈0` in the HAR while 11 smaller uploads succeeded with a normal server `wait`). With no retry, any transient rejection aborts the whole import. URL expiry, the 256 MB limit, and content-length mismatch were ruled out.

## Changes

- **Reliability:** uploadthing path now uses the stable `createUpload` API wrapped in a bounded retry (`lib/uploadthing/uploadWithRetry.ts`, 3 attempts, backoff `[0, 2s, 5s]`). Throws the last error so the existing Retry toast still works.
- **Smoother progress:** `createUpload`'s `onUploadProgress` reports `totalProgress` (overall bytes across the batch), fixing the jumpy asset progress bar. Both S3 and uploadthing paths now share the `onProgress(0–100)` contract.
- **Dedicated protocol step:** the `.netcanvas` uploads first under a new `uploading-protocol` phase (7 phases total) before assets, so a doomed import fails fast.
- **256 MB guard:** oversized protocols are rejected at the import entry with a destructive toast and never queued (`utils/protocolSize.ts`, `MAX_PROTOCOL_UPLOAD_BYTES`). Applied regardless of provider for consistent messaging.
- **Toast UX:** spinner as the toast icon while importing; numeric `%` shown beside every progress bar.

## Test Plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 280/280 pass (new tests: `protocolSize`, `calculateImportProgress` 7-phase, `uploadWithRetry` retry/progress)
- [x] `pnpm knip` — no new unused exports
- [ ] **Manual:** import a ≥200 MB protocol against an UploadThing-backed environment and confirm a transient failure now recovers via retry
- [ ] **Manual:** import a >256 MB protocol and confirm the guard toast appears and it is not queued
- [ ] **Manual:** import a protocol with assets and confirm the protocol step, then the assets step, each show a smooth single-direction progress bar with a `%`

## Notes

- Pre-existing, non-blocking: if the protocol uploads but the *asset* step then fails, the protocol blob isn't cleaned up from storage. Out of scope here; candidate for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)