### PR TITLE
feat(import): upload the protocol file as split parts (reliable large uploads)

### DIFF
--- a/actions/protocols.ts
+++ b/actions/protocols.ts
@@ -10,6 +10,7 @@ import { hashProtocol } from '@codaco/protocol-validation';
 import { getStorageLayer } from '~/lib/storage/layers/StorageLayer';
 import { AssetStorage } from '~/lib/storage/services/AssetStorage';
 import { selectUnreferencedKeys } from '~/lib/protocol/selectUnreferencedKeys';
+import { protocolFilePartsSchema } from '~/schemas/protocolFileParts';
 import { type protocolInsertSchema } from '~/schemas/protocol';
 import { addEvent } from './activityFeed';
 
@@ -55,7 +56,7 @@ export async function deleteProtocols(hashes: string[]) {
 
   const protocolsToBeDeleted = await prisma.protocol.findMany({
     where: { hash: { in: hashes } },
-    select: { id: true, name: true, originalFileKey: true },
+    select: { id: true, name: true, originalFileParts: true },
   });
 
   // Select assets that are ONLY associated with the protocols to be deleted
@@ -72,9 +73,12 @@ export async function deleteProtocols(hashes: string[]) {
     select: { key: true },
   });
 
-  const originalFileKeysToDelete = protocolsToBeDeleted
-    .map((p) => p.originalFileKey)
-    .filter((k): k is string => !!k);
+  const originalFileKeysToDelete = protocolsToBeDeleted.flatMap((p) =>
+    protocolFilePartsSchema
+      .catch([])
+      .parse(p.originalFileParts)
+      .map((part) => part.key),
+  );
 
   // We put file deletion in a separate try/catch because if it fails, we still
   // want to delete the protocol.
@@ -146,9 +150,9 @@ export async function deleteProtocols(hashes: string[]) {
 
 /**
  * Best-effort cleanup of storage blobs that were uploaded during a protocol
- * import that ultimately failed. Any key still referenced by a stored asset or
- * protocol original file is skipped, so blobs in use by other protocols are
- * never deleted. Never throws — cleanup failures must not mask the import error.
+ * import that ultimately failed. Any key still referenced by a stored asset is
+ * skipped, so blobs in use by other protocols are never deleted. Never throws —
+ * cleanup failures must not mask the import error.
  */
 export async function cleanupUploadedFiles(keys: string[]) {
   await requireApiAuth();
@@ -159,23 +163,14 @@ export async function cleanupUploadedFiles(keys: string[]) {
   }
 
   try {
-    const [referencedAssets, referencingProtocols] = await Promise.all([
-      prisma.asset.findMany({
-        where: { key: { in: uploadedKeys } },
-        select: { key: true },
-      }),
-      prisma.protocol.findMany({
-        where: { originalFileKey: { in: uploadedKeys } },
-        select: { originalFileKey: true },
-      }),
-    ]);
+    // Only assets are deduplicated/shared between protocols. Protocol file part
+    // keys are unique per import, so they are always safe to delete.
+    const referencedAssets = await prisma.asset.findMany({
+      where: { key: { in: uploadedKeys } },
+      select: { key: true },
+    });
 
-    const referencedKeys = [
-      ...referencedAssets.map((asset) => asset.key),
-      ...referencingProtocols
-        .map((protocol) => protocol.originalFileKey)
-        .filter((key): key is string => key !== null),
-    ];
+    const referencedKeys = referencedAssets.map((asset) => asset.key);
 
     const keysToDelete = selectUnreferencedKeys(uploadedKeys, referencedKeys);
 
@@ -214,8 +209,13 @@ export async function insertProtocol(
 ) {
   const session = await requireApiAuth();
 
-  const { protocol, protocolName, newAssets, existingAssetIds, originalFile } =
-    input;
+  const {
+    protocol,
+    protocolName,
+    newAssets,
+    existingAssetIds,
+    originalFileParts,
+  } = input;
 
   try {
     const protocolHash = hashProtocol(protocol);
@@ -229,8 +229,7 @@ export async function insertProtocol(
         stages: protocol.stages,
         codebook: protocol.codebook,
         description: protocol.description,
-        originalFileKey: originalFile.key,
-        originalFileUrl: originalFile.url,
+        originalFileParts,
         assets: {
           create: newAssets,
           connect: existingAssetIds.map((assetId: string) => ({ assetId })),

--- a/app/dashboard/_components/ProtocolsTable/ActionsDropdown.tsx
+++ b/app/dashboard/_components/ProtocolsTable/ActionsDropdown.tsx
@@ -15,6 +15,7 @@ import {
 } from '@codaco/fresco-ui/DropdownMenu';
 import { useToast } from '@codaco/fresco-ui/Toast';
 import { useDownload } from '~/hooks/useDownload';
+import { protocolFilePartsSchema } from '~/schemas/protocolFileParts';
 import type { ProtocolWithInterviews } from './ProtocolsTableClient';
 
 export const ActionsDropdown = ({
@@ -34,14 +35,21 @@ export const ActionsDropdown = ({
   };
 
   const handleDownload = async () => {
-    const { originalFileUrl, name } = row.original;
-    if (!originalFileUrl) return;
+    const { originalFileParts, name } = row.original;
+    const parts = protocolFilePartsSchema.parse(originalFileParts);
+    if (parts.length === 0) return;
 
-    const response = await fetch(originalFileUrl);
-    if (!response.ok) {
-      throw new Error('Failed to download protocol file');
-    }
-    const blob = await response.blob();
+    const blobs = await Promise.all(
+      parts.map(async (part) => {
+        const response = await fetch(part.url);
+        if (!response.ok) {
+          throw new Error('Failed to download protocol file');
+        }
+        return response.blob();
+      }),
+    );
+
+    const blob = new Blob(blobs);
     const blobUrl = URL.createObjectURL(blob);
     download(blobUrl, name);
     URL.revokeObjectURL(blobUrl);
@@ -69,7 +77,7 @@ export const ActionsDropdown = ({
         <DropdownMenuContent align="end">
           <DropdownMenuGroup>
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
-            {row.original.originalFileUrl && (
+            {row.original.originalFileParts != null && (
               <DropdownMenuItem
                 onClick={() =>
                   void promise(handleDownload(), {

--- a/app/dashboard/_components/ProtocolsTable/ActionsDropdown.tsx
+++ b/app/dashboard/_components/ProtocolsTable/ActionsDropdown.tsx
@@ -37,7 +37,9 @@ export const ActionsDropdown = ({
   const handleDownload = async () => {
     const { originalFileParts, name } = row.original;
     const parts = protocolFilePartsSchema.parse(originalFileParts);
-    if (parts.length === 0) return;
+    if (parts.length === 0) {
+      throw new Error('Protocol file has no parts to download');
+    }
 
     const blobs = await Promise.all(
       parts.map(async (part) => {

--- a/fresco.config.ts
+++ b/fresco.config.ts
@@ -14,3 +14,7 @@ export const UNCONFIGURED_TIMEOUT = 7200000;
 // This matches the UploadThing per-file limit (256MB) and is enforced
 // regardless of storage provider to keep messaging consistent.
 export const MAX_PROTOCOL_UPLOAD_BYTES = 256 * 1024 * 1024;
+
+// Size of each piece the .netcanvas original is split into for upload. Many
+// small uploads are far more reliable than one large single PUT.
+export const PROTOCOL_UPLOAD_PART_BYTES = 16 * 1024 * 1024;

--- a/hooks/useProtocolImport.tsx
+++ b/hooks/useProtocolImport.tsx
@@ -243,11 +243,13 @@ export const useProtocolImport = () => {
         file,
         PROTOCOL_UPLOAD_PART_BYTES,
       );
-      const uploadedParts = await uploadAssets(protocolParts, (progress) => {
-        updateToastPhase(toastId, 'uploading-protocol', progress);
-      });
-
-      uploadedKeys.push(...uploadedParts.map((part) => part.key));
+      const uploadedParts = await uploadAssets(
+        protocolParts,
+        (progress) => {
+          updateToastPhase(toastId, 'uploading-protocol', progress);
+        },
+        (key) => uploadedKeys.push(key),
+      );
 
       const originalFileParts = protocolParts.map((part) => {
         const uploaded = uploadedParts.find((u) => u.name === part.name);
@@ -266,12 +268,9 @@ export const useProtocolImport = () => {
             (progress) => {
               updateToastPhase(toastId, 'uploading-assets', progress);
             },
+            (key) => uploadedKeys.push(key),
           )
         : [];
-
-      uploadedKeys.push(
-        ...uploadedAssetFiles.map((uploadedFile) => uploadedFile.key),
-      );
 
       newAssetsWithCombinedMetadata = newAssets.map((asset) => {
         const uploadedAsset = uploadedAssetFiles.find(

--- a/hooks/useProtocolImport.tsx
+++ b/hooks/useProtocolImport.tsx
@@ -20,7 +20,11 @@ import {
 } from '~/components/ProtocolImport/calculateImportProgress';
 import ImportToastContent from '~/components/ProtocolImport/ImportToastContent';
 import { useToast } from '@codaco/fresco-ui/Toast';
-import { APP_SUPPORTED_SCHEMA_VERSIONS } from '~/fresco.config';
+import {
+  APP_SUPPORTED_SCHEMA_VERSIONS,
+  PROTOCOL_UPLOAD_PART_BYTES,
+} from '~/fresco.config';
+import { splitFileIntoParts } from '~/lib/protocol/splitFileIntoParts';
 import {
   validateAndMigrateProtocol,
   type ProtocolValidationError,
@@ -232,20 +236,26 @@ export const useProtocolImport = () => {
         throw new Error('Error checking for existing assets');
       }
 
-      // Phase: Uploading protocol
+      // Phase: Uploading protocol (split into pieces for reliable upload)
       updateToastPhase(toastId, 'uploading-protocol');
 
-      const [uploadedOriginalFile] = await uploadAssets([file], (progress) => {
+      const protocolParts = splitFileIntoParts(
+        file,
+        PROTOCOL_UPLOAD_PART_BYTES,
+      );
+      const uploadedParts = await uploadAssets(protocolParts, (progress) => {
         updateToastPhase(toastId, 'uploading-protocol', progress);
       });
 
-      if (uploadedOriginalFile) {
-        uploadedKeys.push(uploadedOriginalFile.key);
-      }
+      uploadedKeys.push(...uploadedParts.map((part) => part.key));
 
-      if (uploadedOriginalFile?.name !== file.name) {
-        throw new Error('Original protocol file upload result mismatch');
-      }
+      const originalFileParts = protocolParts.map((part) => {
+        const uploaded = uploadedParts.find((u) => u.name === part.name);
+        if (!uploaded) {
+          throw new Error('Protocol file part upload result mismatch');
+        }
+        return { key: uploaded.key, url: uploaded.url, size: uploaded.size };
+      });
 
       // Phase: Uploading assets
       updateToastPhase(toastId, 'uploading-assets');
@@ -289,10 +299,7 @@ export const useProtocolImport = () => {
         protocolName: fileName,
         newAssets: [...newAssetsWithCombinedMetadata, ...newApikeyAssets],
         existingAssetIds: existingAssetIds,
-        originalFile: {
-          key: uploadedOriginalFile.key,
-          url: uploadedOriginalFile.url,
-        },
+        originalFileParts,
       });
 
       if (result.error) {

--- a/hooks/useUploadAssets.ts
+++ b/hooks/useUploadAssets.ts
@@ -63,6 +63,7 @@ async function uploadViaS3(
   files: File[],
   urls: PresignedUploadUrl[],
   onProgress?: (progress: number) => void,
+  onUploaded?: (key: string) => void,
 ): Promise<UploadedFile[]> {
   const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
   const loaded = new Array<number>(files.length).fill(0);
@@ -83,6 +84,8 @@ async function uploadViaS3(
       }
     });
 
+    onUploaded?.(presigned.fileKey);
+
     return {
       key: presigned.fileKey,
       url: presigned.publicUrl,
@@ -97,8 +100,9 @@ async function uploadViaS3(
 async function uploadViaUploadThing(
   files: File[],
   onProgress?: (progress: number) => void,
+  onUploaded?: (key: string) => void,
 ): Promise<UploadedFile[]> {
-  return uploadToUploadThingWithRetry(files, onProgress);
+  return uploadToUploadThingWithRetry(files, onProgress, { onUploaded });
 }
 
 export function useUploadAssets() {
@@ -106,15 +110,16 @@ export function useUploadAssets() {
     async (
       files: File[],
       onProgress?: (progress: number) => void,
+      onUploaded?: (key: string) => void,
     ): Promise<UploadedFile[]> => {
       const fileMeta = files.map((f) => ({ name: f.name, size: f.size }));
       const presign = await fetchPresignResponse(fileMeta);
 
       if (presign.provider === 'uploadthing') {
-        return uploadViaUploadThing(files, onProgress);
+        return uploadViaUploadThing(files, onProgress, onUploaded);
       }
 
-      return uploadViaS3(files, presign.urls, onProgress);
+      return uploadViaS3(files, presign.urls, onProgress, onUploaded);
     },
     [],
   );

--- a/lib/db/migrations/20260603120000_split_protocol_file_parts/migration.sql
+++ b/lib/db/migrations/20260603120000_split_protocol_file_parts/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Protocol" DROP COLUMN "originalFileKey",
+DROP COLUMN "originalFileUrl",
+ADD COLUMN "originalFileParts" JSONB;

--- a/lib/db/schema.prisma
+++ b/lib/db/schema.prisma
@@ -60,20 +60,19 @@ model WebAuthnCredential {
 }
 
 model Protocol {
-  id            String      @id @default(cuid())
-  hash          String      @unique
-  name          String
-  schemaVersion Int
-  description   String?
-  importedAt    DateTime    @default(now())
-  lastModified  DateTime
-  stages        Json
-  codebook      Json
-  assets        Asset[]
-  interviews    Interview[]
-  experiments   Json?
-  originalFileKey String?
-  originalFileUrl String?
+  id                String      @id @default(cuid())
+  hash              String      @unique
+  name              String
+  schemaVersion     Int
+  description       String?
+  importedAt        DateTime    @default(now())
+  lastModified      DateTime
+  stages            Json
+  codebook          Json
+  assets            Asset[]
+  interviews        Interview[]
+  experiments       Json?
+  originalFileParts Json?
 }
 
 model Asset {

--- a/lib/protocol/__tests__/splitFileIntoParts.test.ts
+++ b/lib/protocol/__tests__/splitFileIntoParts.test.ts
@@ -34,4 +34,11 @@ describe('splitFileIntoParts', () => {
     const recombined = new Uint8Array(await new Blob(parts).arrayBuffer());
     expect(recombined).toEqual(original);
   });
+
+  it('throws for a non-positive or non-finite part size', () => {
+    expect(() => splitFileIntoParts(makeFile(100), 0)).toThrow();
+    expect(() => splitFileIntoParts(makeFile(100), -1)).toThrow();
+    expect(() => splitFileIntoParts(makeFile(100), Number.NaN)).toThrow();
+    expect(() => splitFileIntoParts(makeFile(100), Infinity)).toThrow();
+  });
 });

--- a/lib/protocol/__tests__/splitFileIntoParts.test.ts
+++ b/lib/protocol/__tests__/splitFileIntoParts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { splitFileIntoParts } from '~/lib/protocol/splitFileIntoParts';
+
+function makeFile(bytes: number): File {
+  return new File([new Uint8Array(bytes)], 'protocol.netcanvas');
+}
+
+describe('splitFileIntoParts', () => {
+  it('splits into ceil(size / partBytes) parts with a remainder last part', () => {
+    const parts = splitFileIntoParts(makeFile(2500), 1000);
+    expect(parts).toHaveLength(3);
+    expect(parts.map((p) => p.size)).toEqual([1000, 1000, 500]);
+  });
+
+  it('returns a single part for a file at or below the part size', () => {
+    const parts = splitFileIntoParts(makeFile(800), 1000);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.size).toBe(800);
+  });
+
+  it('names parts in zero-padded order', () => {
+    const parts = splitFileIntoParts(makeFile(2500), 1000);
+    expect(parts.map((p) => p.name)).toEqual([
+      'part-000',
+      'part-001',
+      'part-002',
+    ]);
+  });
+
+  it('reproduces the original bytes exactly when parts are concatenated', async () => {
+    const original = new Uint8Array(2500).map((_, i) => i % 256);
+    const file = new File([original], 'protocol.netcanvas');
+    const parts = splitFileIntoParts(file, 1000);
+    const recombined = new Uint8Array(await new Blob(parts).arrayBuffer());
+    expect(recombined).toEqual(original);
+  });
+});

--- a/lib/protocol/splitFileIntoParts.ts
+++ b/lib/protocol/splitFileIntoParts.ts
@@ -1,0 +1,23 @@
+/**
+ * Splits a file into ordered pieces of at most `partBytes` each. Pieces are
+ * named `part-000`, `part-001`, … so each upload has a unique, stable name that
+ * maps back to its position. Concatenating the returned pieces in array order
+ * reproduces the original file byte-for-byte.
+ */
+export function splitFileIntoParts(file: File, partBytes: number): File[] {
+  const partCount = Math.ceil(file.size / partBytes);
+  const parts: File[] = [];
+
+  for (let index = 0; index < partCount; index++) {
+    const start = index * partBytes;
+    const end = Math.min(start + partBytes, file.size);
+    const name = `part-${String(index).padStart(3, '0')}`;
+    parts.push(
+      new File([file.slice(start, end)], name, {
+        type: 'application/octet-stream',
+      }),
+    );
+  }
+
+  return parts;
+}

--- a/lib/protocol/splitFileIntoParts.ts
+++ b/lib/protocol/splitFileIntoParts.ts
@@ -5,6 +5,10 @@
  * reproduces the original file byte-for-byte.
  */
 export function splitFileIntoParts(file: File, partBytes: number): File[] {
+  if (!Number.isFinite(partBytes) || partBytes <= 0) {
+    throw new Error('partBytes must be a positive, finite number');
+  }
+
   const partCount = Math.ceil(file.size / partBytes);
   const parts: File[] = [];
 

--- a/lib/uploadthing/__tests__/uploadWithRetry.test.ts
+++ b/lib/uploadthing/__tests__/uploadWithRetry.test.ts
@@ -75,4 +75,28 @@ describe('uploadToUploadThingWithRetry', () => {
 
     expect(onProgress).toHaveBeenCalledWith(42);
   });
+
+  it('forwards per-file uploaded keys via onUploaded', async () => {
+    const startUpload = vi.fn(
+      (
+        _files: File[],
+        _onProgress: (p: number) => void,
+        onUploaded: (key: string) => void,
+      ) => {
+        onUploaded('key-1');
+        return Promise.resolve({
+          done: () => Promise.resolve(uploadedFiles),
+        });
+      },
+    );
+    const onUploaded = vi.fn();
+
+    await uploadToUploadThingWithRetry([file], undefined, {
+      backoffMs: NO_BACKOFF,
+      startUpload,
+      onUploaded,
+    });
+
+    expect(onUploaded).toHaveBeenCalledWith('key-1');
+  });
 });

--- a/lib/uploadthing/uploadWithRetry.ts
+++ b/lib/uploadthing/uploadWithRetry.ts
@@ -15,6 +15,7 @@ type AssetUploadHandle = {
 type StartAssetUpload = (
   files: File[],
   onProgress: (totalProgress: number) => void,
+  onUploaded: (key: string) => void,
 ) => Promise<AssetUploadHandle>;
 
 // Delay (ms) applied before attempt index N. Index 0 (first attempt) never
@@ -27,11 +28,23 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 // SDK result to the app's `UploadedFile` shape. `createUpload`'s
 // `onUploadProgress` reports `totalProgress` (overall bytes across the batch),
 // which avoids the per-file progress overwrites that made the bar jump.
-const startAssetUpload: StartAssetUpload = async (files, onProgress) => {
+const startAssetUpload: StartAssetUpload = async (
+  files,
+  onProgress,
+  onUploaded,
+) => {
   const { done } = await createUpload('assetRouter', {
     files,
     onUploadProgress: ({ totalProgress }) => onProgress(totalProgress),
   });
+
+  // Report each file's key as soon as that file finishes, so the caller can
+  // track uploaded blobs for cleanup even if the overall batch later fails.
+  for (const file of files) {
+    void done(file)
+      .then((result) => onUploaded(result.key))
+      .catch(() => undefined);
+  }
 
   return {
     done: async () => {
@@ -55,7 +68,11 @@ const startAssetUpload: StartAssetUpload = async (files, onProgress) => {
 export async function uploadToUploadThingWithRetry(
   files: File[],
   onProgress?: (progress: number) => void,
-  options: { backoffMs?: number[]; startUpload?: StartAssetUpload } = {},
+  options: {
+    backoffMs?: number[];
+    startUpload?: StartAssetUpload;
+    onUploaded?: (key: string) => void;
+  } = {},
 ): Promise<UploadedFile[]> {
   const backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS;
   const startUpload = options.startUpload ?? startAssetUpload;
@@ -68,8 +85,10 @@ export async function uploadToUploadThingWithRetry(
     }
 
     try {
-      const { done } = await startUpload(files, (progress) =>
-        onProgress?.(progress),
+      const { done } = await startUpload(
+        files,
+        (progress) => onProgress?.(progress),
+        (key) => options.onUploaded?.(key),
       );
       return await done();
     } catch (error) {

--- a/schemas/__tests__/protocolFileParts.test.ts
+++ b/schemas/__tests__/protocolFileParts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { protocolFilePartsSchema } from '~/schemas/protocolFileParts';
+
+describe('protocolFilePartsSchema', () => {
+  it('parses a valid ordered parts array', () => {
+    const value = [
+      { key: 'k0', url: 'https://ut/0', size: 10 },
+      { key: 'k1', url: 'https://ut/1', size: 5 },
+    ];
+    expect(protocolFilePartsSchema.parse(value)).toEqual(value);
+  });
+
+  it('rejects a malformed parts value', () => {
+    expect(() => protocolFilePartsSchema.parse({ not: 'an array' })).toThrow();
+    expect(() =>
+      protocolFilePartsSchema.parse([{ key: 'k', url: 'u' }]),
+    ).toThrow();
+  });
+});

--- a/schemas/protocol.ts
+++ b/schemas/protocol.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { CurrentProtocolSchema } from '@codaco/protocol-validation';
 import { z } from 'zod';
+import { protocolFilePartsSchema } from '~/schemas/protocolFileParts';
 
 const assetInsertSchema = z.object({
   key: z.string(),
@@ -19,8 +20,5 @@ export const protocolInsertSchema = z.object({
   protocolName: z.string(),
   newAssets: z.array(assetInsertSchema),
   existingAssetIds: z.array(z.string()),
-  originalFile: z.object({
-    key: z.string(),
-    url: z.string(),
-  }),
+  originalFileParts: protocolFilePartsSchema,
 });

--- a/schemas/protocolFileParts.ts
+++ b/schemas/protocolFileParts.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const protocolFilePartSchema = z.object({
+  key: z.string(),
+  url: z.string(),
+  size: z.number(),
+});
+
+export const protocolFilePartsSchema = z.array(protocolFilePartSchema);
+
+export type ProtocolFilePart = z.infer<typeof protocolFilePartSchema>;

--- a/schemas/protocolFileParts.ts
+++ b/schemas/protocolFileParts.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 
-export const protocolFilePartSchema = z.object({
-  key: z.string(),
-  url: z.string(),
-  size: z.number(),
-});
-
-export const protocolFilePartsSchema = z.array(protocolFilePartSchema);
-
-export type ProtocolFilePart = z.infer<typeof protocolFilePartSchema>;
+export const protocolFilePartsSchema = z.array(
+  z.object({
+    key: z.string(),
+    url: z.string(),
+    size: z.number(),
+  }),
+);


### PR DESCRIPTION
## Summary

Follow-up to #771. Eliminates the unreliable large single PUT for the `.netcanvas` original by **splitting it into ordered 16 MB pieces**, each uploaded as an ordinary small file, and **reassembling them in the browser on download**.

This is the fix that actually addresses both problems we found with large UploadThing uploads:
- **Reliability** — small pieces rarely trip the intermittent ingest `400`; each retries cheaply via the existing retry wrapper.
- **Fast-fail** — a doomed piece fails in seconds instead of ~150 s.
- Uses only supported primitives (normal small uploads) — no hand-rolled ingest protocol, no server-side upload (impractical on serverless), no browser-streaming experiments.

The `.netcanvas` original is consumed **only** by the dashboard Download button (interviews read `stages`/`codebook`/`assets` from the DB), so the blast radius is just import + download + delete/cleanup.

## Changes

- **Split helper** `lib/protocol/splitFileIntoParts.ts` — pure, byte-exact, names pieces `part-000…`.
- **Schema:** `Protocol.originalFileParts Json?` (ordered `[{key,url,size}]`) **replaces** `originalFileKey`/`originalFileUrl` (+ migration). **No backward compatibility** — `next` is unreleased / dev-only, so the old columns are dropped outright.
- **Import** (`useProtocolImport`): split the file, upload pieces through the existing `uploadAssets` retry path, match results to pieces by name, store the ordered parts. Failed-import cleanup already tracks every piece key.
- **Download** (`ActionsDropdown`): fetch the parts in parallel, `new Blob(parts in order)` → download. Byte-for-byte identical to the original.
- **Cleanup** (`cleanupUploadedFiles`): simplified to an assets-only reference check — protocol piece keys are unique per import, never shared.
- Client-safe `schemas/protocolFileParts.ts` so the browser download can validate the JSON.

## ⚠️ Migration / deploy note

Includes a Prisma migration (`20260603120000_split_protocol_file_parts`) that **drops** `originalFileKey`/`originalFileUrl` and **adds** `originalFileParts`. Dev protocols imported before this lose their download link (`originalFileParts` is null → the Download item is hidden); re-import to restore it. Run migrations on deploy.

## Test Plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 293/293 pass (new: `splitFileIntoParts` incl. byte-exact reassembly, `protocolFileParts` schema)
- [x] `pnpm knip` — clean
- [ ] **Manual:** import a ~200 MB protocol against an UploadThing env — confirm the "uploading protocol" step uploads multiple small pieces reliably and fast
- [ ] **Manual:** download it and verify the file is **byte-for-byte identical** (compare checksums) and opens in Network Canvas
- [ ] **Manual:** delete it and confirm all piece blobs are removed from storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)