### PR TITLE
fix(dashboard): show finished interviews as 100% progress

### DIFF
--- a/app/dashboard/_components/InterviewsTable/Columns.tsx
+++ b/app/dashboard/_components/InterviewsTable/Columns.tsx
@@ -19,6 +19,7 @@ import type {
   GetInterviewsQuery,
   InterviewFilterOptions,
 } from '~/queries/interviews';
+import { computeInterviewProgress } from './computeInterviewProgress';
 import NetworkSummary from './NetworkSummary';
 
 type InterviewRow = GetInterviewsQuery[number];
@@ -166,10 +167,12 @@ export const InterviewColumns = (
   {
     id: 'progress',
     sortingFn: 'basic',
-    accessorFn: (row) => {
-      const stageCount = row.protocol.stageCount;
-      return stageCount > 0 ? (row.currentStep / stageCount) * 100 : 0;
-    },
+    accessorFn: (row) =>
+      computeInterviewProgress({
+        finishTime: row.finishTime,
+        currentStep: row.currentStep,
+        stageCount: row.protocol.stageCount,
+      }),
     meta: {
       filterType: 'range',
       filterConfig: {
@@ -192,9 +195,11 @@ export const InterviewColumns = (
       );
     },
     cell: ({ row }) => {
-      const stageCount = row.original.protocol.stageCount;
-      const progress =
-        stageCount > 0 ? (row.original.currentStep / stageCount) * 100 : 0;
+      const progress = computeInterviewProgress({
+        finishTime: row.original.finishTime,
+        currentStep: row.original.currentStep,
+        stageCount: row.original.protocol.stageCount,
+      });
       return (
         <div className="flex items-center whitespace-nowrap">
           <ProgressBar

--- a/app/dashboard/_components/InterviewsTable/__tests__/computeInterviewProgress.test.ts
+++ b/app/dashboard/_components/InterviewsTable/__tests__/computeInterviewProgress.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { computeInterviewProgress } from '../computeInterviewProgress';
+
+describe('computeInterviewProgress', () => {
+  it('returns 100 for a finished interview even when currentStep is below stageCount', () => {
+    // A finished interview never advances currentStep to stageCount: the finish
+    // screen is an appended stage that is not counted, and the finish flow only
+    // records finishTime. Completion is determined by finishTime, not currentStep.
+    expect(
+      computeInterviewProgress({
+        finishTime: new Date(),
+        currentStep: 11,
+        stageCount: 12,
+      }),
+    ).toBe(100);
+  });
+
+  it('returns 100 for a finished interview regardless of stageCount', () => {
+    expect(
+      computeInterviewProgress({
+        finishTime: new Date(),
+        currentStep: 0,
+        stageCount: 0,
+      }),
+    ).toBe(100);
+  });
+
+  it('returns the proportional percentage for an in-progress interview', () => {
+    expect(
+      computeInterviewProgress({
+        finishTime: null,
+        currentStep: 3,
+        stageCount: 12,
+      }),
+    ).toBe(25);
+  });
+
+  it('returns 0 for a not-started interview', () => {
+    expect(
+      computeInterviewProgress({
+        finishTime: null,
+        currentStep: 0,
+        stageCount: 12,
+      }),
+    ).toBe(0);
+  });
+
+  it('returns 0 when stageCount is 0 and the interview is unfinished', () => {
+    expect(
+      computeInterviewProgress({
+        finishTime: null,
+        currentStep: 0,
+        stageCount: 0,
+      }),
+    ).toBe(0);
+  });
+});

--- a/app/dashboard/_components/InterviewsTable/__tests__/computeInterviewProgress.test.ts
+++ b/app/dashboard/_components/InterviewsTable/__tests__/computeInterviewProgress.test.ts
@@ -3,9 +3,8 @@ import { computeInterviewProgress } from '../computeInterviewProgress';
 
 describe('computeInterviewProgress', () => {
   it('returns 100 for a finished interview even when currentStep is below stageCount', () => {
-    // A finished interview never advances currentStep to stageCount: the finish
-    // screen is an appended stage that is not counted, and the finish flow only
-    // records finishTime. Completion is determined by finishTime, not currentStep.
+    // Completion is determined by finishTime, not currentStep: the finish flow
+    // records finishTime but does not reliably advance currentStep to the end.
     expect(
       computeInterviewProgress({
         finishTime: new Date(),
@@ -25,14 +24,28 @@ describe('computeInterviewProgress', () => {
     ).toBe(100);
   });
 
-  it('returns the proportional percentage for an in-progress interview', () => {
+  it('divides by stageCount + 1 to match the package, which appends a finish stage', () => {
+    // @codaco/interview indexes currentStep against [...protocolStages, finish],
+    // so the true step total is stageCount + 1.
     expect(
       computeInterviewProgress({
         finishTime: null,
-        currentStep: 3,
-        stageCount: 12,
+        currentStep: 1,
+        stageCount: 3,
       }),
     ).toBe(25);
+  });
+
+  it('reports an unfinished interview parked on the finish screen below 100%', () => {
+    // currentStep === stageCount means the participant reached the appended
+    // finish screen but has not finished; finishTime is the only 100% signal.
+    expect(
+      computeInterviewProgress({
+        finishTime: null,
+        currentStep: 12,
+        stageCount: 12,
+      }),
+    ).toBeCloseTo((12 / 13) * 100);
   });
 
   it('returns 0 for a not-started interview', () => {
@@ -45,7 +58,7 @@ describe('computeInterviewProgress', () => {
     ).toBe(0);
   });
 
-  it('returns 0 when stageCount is 0 and the interview is unfinished', () => {
+  it('returns 0 for a not-started interview when stageCount is 0', () => {
     expect(
       computeInterviewProgress({
         finishTime: null,

--- a/app/dashboard/_components/InterviewsTable/buildInterviewWhere.ts
+++ b/app/dashboard/_components/InterviewsTable/buildInterviewWhere.ts
@@ -27,12 +27,14 @@ function operatorSql(op: NetworkCondition['operator']): Prisma.Sql {
 
 /**
  * Progress percentage expression mirroring `computeInterviewProgress`: a
- * finished interview (finishTime set) is 100%, otherwise progress is derived
- * from currentStep / protocol stage count. Assumes the aliases `i` (Interview)
- * and `p` (Protocol).
+ * finished interview (finishTime set) is 100%, otherwise progress is
+ * currentStep / (protocol stage count + 1). The +1 accounts for the finish
+ * stage that @codaco/interview appends to the stage list, against which
+ * currentStep is indexed. Assumes the aliases `i` (Interview) and `p`
+ * (Protocol).
  */
 const PROGRESS_SQL =
-  '(CASE WHEN i."finishTime" IS NOT NULL THEN 100 WHEN COALESCE(jsonb_array_length(p."stages"::jsonb),0) > 0 THEN (i."currentStep"::float / jsonb_array_length(p."stages"::jsonb)) * 100 ELSE 0 END)';
+  '(CASE WHEN i."finishTime" IS NOT NULL THEN 100 ELSE (i."currentStep"::float / (COALESCE(jsonb_array_length(p."stages"::jsonb),0) + 1)) * 100 END)';
 
 /**
  * Builds the WHERE predicate (without the `WHERE` keyword) for the interview

--- a/app/dashboard/_components/InterviewsTable/buildInterviewWhere.ts
+++ b/app/dashboard/_components/InterviewsTable/buildInterviewWhere.ts
@@ -26,6 +26,15 @@ function operatorSql(op: NetworkCondition['operator']): Prisma.Sql {
 }
 
 /**
+ * Progress percentage expression mirroring `computeInterviewProgress`: a
+ * finished interview (finishTime set) is 100%, otherwise progress is derived
+ * from currentStep / protocol stage count. Assumes the aliases `i` (Interview)
+ * and `p` (Protocol).
+ */
+const PROGRESS_SQL =
+  '(CASE WHEN i."finishTime" IS NOT NULL THEN 100 WHEN COALESCE(jsonb_array_length(p."stages"::jsonb),0) > 0 THEN (i."currentStep"::float / jsonb_array_length(p."stages"::jsonb)) * 100 ELSE 0 END)';
+
+/**
  * Builds the WHERE predicate (without the `WHERE` keyword) for the interview
  * list. Returns `Prisma.empty` when no filters are active. Column references
  * assume the aliases `i` (Interview), `p` (Protocol), `par` (Participant).
@@ -66,9 +75,7 @@ export function buildInterviewWhere(
     const min = Number(progress.lo);
     const max = Number(progress.hi);
     conditions.push(
-      Prisma.sql`(CASE WHEN COALESCE(jsonb_array_length(p."stages"::jsonb),0) > 0
-        THEN (i."currentStep"::float / jsonb_array_length(p."stages"::jsonb)) * 100
-        ELSE 0 END) BETWEEN ${min} AND ${max}`,
+      Prisma.sql`${Prisma.raw(PROGRESS_SQL)} BETWEEN ${min} AND ${max}`,
     );
   }
 
@@ -103,8 +110,7 @@ const SORT_COLUMN: Record<string, string | undefined> = {
   startTime: 'i."startTime"',
   lastUpdated: 'i."lastUpdated"',
   exportTime: 'i."exportTime"',
-  progress:
-    '(CASE WHEN COALESCE(jsonb_array_length(p."stages"::jsonb),0) > 0 THEN (i."currentStep"::float / jsonb_array_length(p."stages"::jsonb)) * 100 ELSE 0 END)',
+  progress: PROGRESS_SQL,
 };
 
 export function buildInterviewOrderBy(

--- a/app/dashboard/_components/InterviewsTable/computeInterviewProgress.ts
+++ b/app/dashboard/_components/InterviewsTable/computeInterviewProgress.ts
@@ -1,0 +1,20 @@
+type InterviewProgressInput = {
+  finishTime: Date | null;
+  currentStep: number;
+  stageCount: number;
+};
+
+/**
+ * Completion is determined by finishTime, not currentStep. A finished interview
+ * never advances currentStep to stageCount because the finish screen is an
+ * appended stage that isn't counted and the finish flow only records finishTime,
+ * so deriving progress from currentStep alone caps it below 100%.
+ */
+export function computeInterviewProgress({
+  finishTime,
+  currentStep,
+  stageCount,
+}: InterviewProgressInput): number {
+  if (finishTime) return 100;
+  return stageCount > 0 ? (currentStep / stageCount) * 100 : 0;
+}

--- a/app/dashboard/_components/InterviewsTable/computeInterviewProgress.ts
+++ b/app/dashboard/_components/InterviewsTable/computeInterviewProgress.ts
@@ -5,10 +5,15 @@ type InterviewProgressInput = {
 };
 
 /**
- * Completion is determined by finishTime, not currentStep. A finished interview
- * never advances currentStep to stageCount because the finish screen is an
- * appended stage that isn't counted and the finish flow only records finishTime,
- * so deriving progress from currentStep alone caps it below 100%.
+ * Progress for an interview row, kept in step with @codaco/interview.
+ *
+ * Completion is determined by finishTime, not currentStep: the finish flow
+ * records finishTime but does not reliably advance currentStep to the end.
+ *
+ * For in-progress interviews the denominator is stageCount + 1, because the
+ * package indexes currentStep against [...protocolStages, finishStage] — the
+ * appended finish screen makes the true step total one greater than the
+ * protocol's stage count.
  */
 export function computeInterviewProgress({
   finishTime,
@@ -16,5 +21,5 @@ export function computeInterviewProgress({
   stageCount,
 }: InterviewProgressInput): number {
   if (finishTime) return 100;
-  return stageCount > 0 ? (currentStep / stageCount) * 100 : 0;
+  return (currentStep / (stageCount + 1)) * 100;
 }


### PR DESCRIPTION
## Problem

Completing an interview (reaching the finish screen and clicking **Finish Interview**) left the interview showing **92%** on the interviews page instead of 100% — and, more generally, dashboard progress drifted from what the participant actually saw in the interview.

## Root cause

Progress on the interviews table was computed as `currentStep / stageCount` (protocol stage count). Two issues with that:

1. **Wrong denominator / drift.** `@codaco/interview` appends a synthetic `FinishSession` stage to the stage list, so `currentStep` is indexed against **`P + 1`** stages (protocol stages + finish), ranging `0 … P`. Dividing by `P` drifts every in-progress percentage away from the package's own progress (which divides by `P + 1` and reaches 100% on the finish screen).
2. **`currentStep` is not a reliable completion signal.** The finish-screen step (`currentStep === P`) often never persists: sync is debounced 3s and only fires on session-slice changes, and clicking Finish `router.push`es away before the trailing sync lands. The `/finish` endpoint records only `finishTime`. So a finished interview's stored `currentStep` typically stays at `P − 1` → `(P − 1) / P` ≈ 92%.

## Fix

- **Completion is read from `finishTime`** — the canonical completion signal used elsewhere in the codebase — so a finished interview is **100%**, retroactively, with no migration.
- **In-progress uses `currentStep / (stageCount + 1)`** to match the package's step model (the appended finish stage), so dashboard numbers stop drifting from the interview.

Applied consistently across all three progress computations:
- New pure helper `computeInterviewProgress` (display cell + sort accessor in `Columns.tsx`)
- Shared `PROGRESS_SQL` expression with the same logic (progress filter + sort in `buildInterviewWhere.ts`)

**Bonus:** the dashboard's *Complete* (100%) and *In Progress* (1–99%) filter presets now behave correctly — previously no interview could ever reach 100%, so finished ones were mis-filed as "In Progress".

## Follow-up

The underlying drift is an abstraction leak in `@codaco/interview`: it leaks the appended `FinishSession` sentinel into the host-facing `currentStep` without exposing the matching total or its computed progress. Tracked for a proper package-side fix (expose participant-facing progress via the sync contract) in complexdatacollective/network-canvas-monorepo#687.

## Testing

- Unit tests for `computeInterviewProgress` (6 cases) — written test-first.
- `pnpm typecheck` → 0 errors
- Full unit suite → 322 passed (37 files)
- ESLint + Prettier clean