### PR TITLE
refactor(scripts): treat current schema 8 as the only schema 8

### DIFF
--- a/scripts/__tests__/migrate-protocols-to-v8.test.ts
+++ b/scripts/__tests__/migrate-protocols-to-v8.test.ts
@@ -257,113 +257,11 @@ describe('migrateProtocolsToV8', () => {
     expect(call.data.codebook.node.person).not.toHaveProperty('iconVariant');
   });
 
-  it('preserves authored v8 state (node shape, required semantics) when normalizing', async () => {
-    // A mislabelled-v8 body: legacy pre-v8 field shapes (iconVariant, Toggle
-    // options) force re-normalization, but the row ALSO carries authored v8
-    // state the v7→v8 migration would destroy. Since protocol-validation
-    // 11.9.0 tightened CurrentProtocolSchema, rows like this can newly fail
-    // conformance, and normalization must not corrupt the authored values.
-    //
-    // Required-flag semantics mirror what Fresco's legacy form engine
-    // actually did: minLength/minSelected failed empty values (so the
-    // migration's required:true preserves observed behaviour and must stay),
-    // while minValue passed empty values (so a min-valued variable without
-    // `required` was optional and must remain so). Explicit `required` values
-    // are always restored.
+  it('normalizes non-conformant asset-referencing protocols', async () => {
+    // The re-migration input must include the manifest reconstructed from the
+    // Asset rows, or migration of any asset-referencing protocol would fail
+    // its output validation.
     const mixed = makeV7Protocol();
-    const personNode = mixed.codebook.node.person as Record<string, unknown>;
-    personNode.shape = { default: 'square' };
-    Object.assign(personNode.variables as Record<string, unknown>, {
-      nickname: {
-        name: 'nickname',
-        type: 'text',
-        component: 'Text',
-        validation: { minLength: 2 },
-      },
-      age: {
-        name: 'age',
-        type: 'number',
-        component: 'Number',
-        validation: { minValue: 1 },
-      },
-      bio: {
-        name: 'bio',
-        type: 'text',
-        component: 'TextArea',
-        validation: { minLength: 5, required: false },
-      },
-    });
-
-    const prisma = makeMockPrisma();
-    prisma.protocol.findMany.mockResolvedValue([
-      {
-        id: 'cm-authored-v8',
-        assets: [],
-        name: 'Authored.netcanvas',
-        schemaVersion: 8,
-        stages: mixed.stages,
-        codebook: mixed.codebook,
-        experiments: null,
-        description: mixed.description,
-        lastModified: new Date(mixed.lastModified),
-      },
-    ]);
-
-    await migrateProtocolsToV8(
-      prisma as unknown as Parameters<typeof migrateProtocolsToV8>[0],
-    );
-
-    expect(prisma.protocol.update).toHaveBeenCalledTimes(1);
-
-    type UpdateCallArg = {
-      data: {
-        codebook: {
-          node: {
-            person: {
-              icon: string;
-              shape: Record<string, unknown>;
-              variables: Record<
-                string,
-                { validation?: Record<string, unknown> }
-              >;
-            };
-          };
-        };
-      };
-    };
-    const call = prisma.protocol.update.mock.calls[0]?.[0] as UpdateCallArg;
-    const person = call.data.codebook.node.person;
-
-    // Legacy shapes were still normalized...
-    expect(person.icon).toBe('add-a-person');
-    expect(person).not.toHaveProperty('iconVariant');
-    // ...but the authored shape config survives instead of being reset to
-    // { default: 'circle' }...
-    expect(person.shape).toEqual({ default: 'square' });
-    // ...minLength keeps the migration's required:true (legacy engine failed
-    // empty values, so the field was effectively required)...
-    expect(person.variables.nickname?.validation).toEqual({
-      minLength: 2,
-      required: true,
-    });
-    // ...minValue-only stays optional (legacy engine passed empty values)...
-    expect(person.variables.age?.validation).toEqual({ minValue: 1 });
-    // ...and an explicit required value is restored verbatim.
-    expect(person.variables.bio?.validation).toEqual({
-      minLength: 5,
-      required: false,
-    });
-  });
-
-  it('normalizes asset-referencing protocols without discarding authored state', async () => {
-    // The whole-protocol schema cross-references roster/geospatial dataSource
-    // ids against the asset manifest. Both the conformance check and the
-    // restored-body re-parse must reconstruct the manifest from the Asset
-    // rows, or every asset-referencing protocol would re-normalize on each
-    // deploy and lose its authored state to the fallback path.
-    const mixed = makeV7Protocol();
-    const personNode = mixed.codebook.node.person as Record<string, unknown>;
-    personNode.shape = { default: 'square' };
     mixed.stages.push({
       id: 'stage-roster',
       type: 'NameGeneratorRoster',
@@ -400,18 +298,6 @@ describe('migrateProtocolsToV8', () => {
     );
 
     expect(prisma.protocol.update).toHaveBeenCalledTimes(1);
-
-    type UpdateCallArg = {
-      data: {
-        codebook: { node: { person: { shape: Record<string, unknown> } } };
-      };
-    };
-    const call = prisma.protocol.update.mock.calls[0]?.[0] as UpdateCallArg;
-    // Restoration succeeded (no fallback to the shape-resetting plain output)
-    // even though the protocol references a stored asset.
-    expect(call.data.codebook.node.person.shape).toEqual({
-      default: 'square',
-    });
   });
 
   it('skips conformant asset-referencing protocols instead of re-normalizing them each deploy', async () => {
@@ -468,55 +354,6 @@ describe('migrateProtocolsToV8', () => {
     );
 
     expect(prisma.protocol.update).not.toHaveBeenCalled();
-  });
-
-  it('falls back to the plain re-migration output when authored state cannot be restored', async () => {
-    const warnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => undefined);
-
-    // The authored shape config is invalid v8, so restoring it would produce
-    // a body that fails the strict schema; normalization must persist the
-    // valid migration output instead of writing a broken body back.
-    const mixed = makeV7Protocol();
-    (mixed.codebook.node.person as Record<string, unknown>).shape = {
-      default: 'not-a-real-shape',
-    };
-
-    const prisma = makeMockPrisma();
-    prisma.protocol.findMany.mockResolvedValue([
-      {
-        id: 'cm-bad-authored',
-        assets: [],
-        name: 'BadAuthored.netcanvas',
-        schemaVersion: 8,
-        stages: mixed.stages,
-        codebook: mixed.codebook,
-        experiments: null,
-        description: mixed.description,
-        lastModified: new Date(mixed.lastModified),
-      },
-    ]);
-
-    await migrateProtocolsToV8(
-      prisma as unknown as Parameters<typeof migrateProtocolsToV8>[0],
-    );
-
-    expect(prisma.protocol.update).toHaveBeenCalledTimes(1);
-
-    type UpdateCallArg = {
-      data: {
-        codebook: { node: { person: { shape: Record<string, unknown> } } };
-      };
-    };
-    const call = prisma.protocol.update.mock.calls[0]?.[0] as UpdateCallArg;
-    expect(call.data.codebook.node.person.shape).toEqual({
-      default: 'circle',
-    });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('BadAuthored.netcanvas'),
-    );
-    warnSpy.mockRestore();
   });
 
   it('conformant schemaVersion-8 protocols are left untouched', async () => {

--- a/scripts/migrate-protocols-to-v8.ts
+++ b/scripts/migrate-protocols-to-v8.ts
@@ -152,92 +152,13 @@ async function migrateOneProtocol(
   );
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
- * Copy the original `validation.required` state back onto migrated variables.
- * The v7→v8 migration adds `required: true` to any variable carrying a min*
- * rule without an explicit `required`, because pre-v8 runtimes coupled the
- * two. Fresco's legacy form engine only actually coupled `minLength` and
- * `minSelected` (an empty value failed those validators); `minValue` passed
- * empty values, so a min-valued variable without `required` behaved as
- * optional. Restore the stored state exactly where it matches the behaviour
- * participants observed: explicit `required` values are always restored, and
- * the migration-added `required: true` is removed only when the variable's
- * min validators are limited to `minValue`.
- */
-function restoreRequiredFlags(origVars: unknown, candVars: unknown): void {
-  if (!isRecord(origVars) || !isRecord(candVars)) return;
-
-  for (const [varId, candVar] of Object.entries(candVars)) {
-    const origVar = origVars[varId];
-    if (!isRecord(origVar) || !isRecord(candVar)) continue;
-
-    const origValidation = origVar.validation;
-    const candValidation = candVar.validation;
-    if (!isRecord(origValidation) || !isRecord(candValidation)) continue;
-
-    if ('required' in origValidation) {
-      candValidation.required = origValidation.required;
-    } else if (
-      !('minLength' in origValidation) &&
-      !('minSelected' in origValidation)
-    ) {
-      delete candValidation.required;
-    }
-  }
-}
-
-/**
- * Re-running the v7→v8 migration on a body that is already v8-authored is not
- * idempotent: it unconditionally resets every node type's `shape` config to
- * `{ default: 'circle' }` and adds `required: true` next to min* validators.
- * On a mislabelled-v8 row those are authored v8 values, not legacy shapes, so
- * copy them back from the stored codebook. Original values are only restored
- * where they are structurally plausible (object shape configs, existing
- * validation objects); the caller re-parses the result against the strict
- * schema before persisting, so a bad restoration can never be written.
- */
-function restoreAuthoredV8State(
-  origCodebook: Record<string, unknown>,
-  candCodebook: Record<string, unknown>,
-): void {
-  for (const entity of ['node', 'edge'] as const) {
-    const origEntity = origCodebook[entity];
-    const candEntity = candCodebook[entity];
-    if (!isRecord(origEntity) || !isRecord(candEntity)) continue;
-
-    for (const [typeId, candType] of Object.entries(candEntity)) {
-      const origType = origEntity[typeId];
-      if (!isRecord(origType) || !isRecord(candType)) continue;
-
-      if (entity === 'node' && isRecord(origType.shape)) {
-        candType.shape = origType.shape;
-      }
-
-      restoreRequiredFlags(origType.variables, candType.variables);
-    }
-  }
-
-  const origEgo = origCodebook.ego;
-  const candEgo = candCodebook.ego;
-  if (isRecord(origEgo) && isRecord(candEgo)) {
-    restoreRequiredFlags(origEgo.variables, candEgo.variables);
-  }
-}
-
 /**
  * Normalize a protocol stored as schemaVersion 8 whose body fails the strict
- * read-time schema — either because it still carries pre-v8 field shapes
- * (e.g. object-form `automaticLayout`) or because it was imported under a
- * laxer historical validator (e.g. out-of-palette OrdinalBin colors or an
- * orphaned CategoricalBin `otherOptionLabel`, both tightened in
- * protocol-validation 11.9.0). Re-running the v7→v8 migration rewrites those
- * shapes; authored v8-only state the re-migration would destroy (node shape
- * configs, optional-field semantics, `experiments`) is preserved from the
- * stored row. Throws if the content is genuinely invalid and cannot be
+ * read-time schema (e.g. dev-era rows still carrying pre-v8 field shapes such
+ * as object-form `automaticLayout`). Schema 8 was never released, so the
+ * current schema is the only schema 8 that exists; a non-conformant row is
+ * simply invalid data and is mechanically coerced by re-running the v7→v8
+ * migration. Throws if the content is genuinely invalid and cannot be
  * migrated.
  */
 async function normalizeMislabelledV8(
@@ -245,11 +166,6 @@ async function normalizeMislabelledV8(
   row: ProtocolRow,
 ): Promise<void> {
   const cleanName = row.name.replace(/\.netcanvas$/i, '');
-
-  // migrateProtocol shares nested objects with its input and mutates some of
-  // them in place (e.g. setting `required` on a variable's validation), so
-  // snapshot the stored codebook before migrating to keep a true original.
-  const origCodebook: unknown = structuredClone(row.codebook);
 
   const asV7 = {
     name: cleanName,
@@ -261,49 +177,17 @@ async function normalizeMislabelledV8(
 
   const migrated = migrateProtocol(asV7, 8, { name: cleanName });
 
-  // Restore authored v8 state onto a clone of the migration output, then keep
-  // the restored body only if it still satisfies the strict schema.
-  let finalProtocol: Pick<typeof migrated, 'stages' | 'codebook'> = migrated;
-  const candidate: unknown = structuredClone(migrated);
-  if (
-    isRecord(candidate) &&
-    isRecord(candidate.codebook) &&
-    isRecord(origCodebook)
-  ) {
-    restoreAuthoredV8State(origCodebook, candidate.codebook);
-
-    const reparsed = CurrentProtocolSchema.safeParse({
-      name: cleanName,
-      schemaVersion: 8,
-      stages: candidate.stages,
-      codebook: candidate.codebook,
-      experiments: row.experiments ?? {},
-      // Required for asset-referencing stages; without it the restored body
-      // would always fail this parse and needlessly discard authored state.
-      assetManifest: buildAssetManifest(row.assets),
-    });
-
-    if (reparsed.success) {
-      finalProtocol = reparsed.data;
-    } else {
-      console.warn(
-        `Could not preserve authored v8 state while normalizing "${row.name}" ` +
-          `(id=${row.id}); persisting the plain re-migration output instead.`,
-      );
-    }
-  }
-
   // The hash is derived from stages + codebook only, so re-normalizing to v8
   // gives the same hash the import flow would now compute for this protocol.
-  const newHash = hashProtocol({ ...migrated, ...finalProtocol });
+  const newHash = hashProtocol(migrated);
 
   await writeMigratedProtocol(
     prisma,
     row,
     {
       schemaVersion: 8,
-      stages: finalProtocol.stages as Prisma.InputJsonValue,
-      codebook: finalProtocol.codebook,
+      stages: migrated.stages as Prisma.InputJsonValue,
+      codebook: migrated.codebook,
       // Preserve the protocol's existing v8-only experiments; a v7→v8 migration
       // has no knowledge of them and would otherwise reset them to its default.
       experiments: row.experiments ?? Prisma.JsonNull,
@@ -324,11 +208,12 @@ async function normalizeMislabelledV8(
  * Two classes of protocol need work:
  * - schemaVersion < 8: migrated up to v8 (hard-fails the deploy on error, since
  *   the new interview module cannot read pre-v8 data at all).
- * - schemaVersion 8 but non-conformant: imported under a laxer historical
- *   validator, these are labelled v8 while still carrying pre-v8 field shapes.
- *   They are re-normalized. If a protocol's content is genuinely invalid and
- *   cannot be migrated, it is logged and left in place — the read path degrades
- *   gracefully rather than crashing, so one bad protocol must not abort the deploy.
+ * - schemaVersion 8 but non-conformant: schema 8 was never released, so these
+ *   are invalid dev-era rows (e.g. still carrying pre-v8 field shapes) that
+ *   are mechanically re-normalized through the v7→v8 migration. If a
+ *   protocol's content is genuinely invalid and cannot be migrated, it is
+ *   logged and left in place — the read path degrades gracefully rather than
+ *   crashing, so one bad protocol must not abort the deploy.
  *
  * Idempotent: conformant v8 protocols are skipped.
  */


### PR DESCRIPTION
Follow-up to #834, per the clarification that **schema 8 evolved during development but was never released** — the current schema 8 (protocol-validation 11.9+) is the only version that exists.

## Removed

The authored-state restoration machinery added to `normalizeMislabelledV8` in #834 (`restoreAuthoredV8State`, `restoreRequiredFlags`, the pre-migration codebook snapshot, and the strict-schema re-parse) existed solely to preserve protocol data authored under interim, unreleased iterations of schema 8. Under the schema-8-was-never-released model, such rows are simply invalid dev-era data: released Fresco supports schema 7 only (`APP_SUPPORTED_SCHEMA_VERSIONS = [7]` on `main`), so no production database contains schemaVersion-8 rows. Non-conformant v8 rows are now mechanically coerced by the plain v7→v8 re-migration, as before #834. Net −296 lines.

## Kept

- The **asset-manifest reconstruction in `isConformantV8`** from #834 — that fixed a *current-schema* bug: `CurrentProtocolSchema` cross-references roster/geospatial `dataSource` ids against the manifest, so without it every conformant asset-referencing protocol failed the conformance check and was destructively re-migrated on every deploy. Its regression test stays, plus a slim test that non-conformant asset-referencing rows normalize successfully.
- `migrateOneProtocol` (schemaVersion < 8) untouched — schema-7 rows are real released data and upstream's migration semantics (including the `required: true` materialization) are the intended path.

## Verification

- Migration script tests: 13 pass
- `pnpm typecheck`, `pnpm lint` pass