### PR TITLE
Fix: finish-screen double submission

### DIFF
--- a/app/(interview)/interview/[interviewId]/InterviewClient.tsx
+++ b/app/(interview)/interview/[interviewId]/InterviewClient.tsx
@@ -12,7 +12,8 @@ import {
 import { useRouter } from 'next/navigation';
 import { parseAsInteger, useQueryState } from 'nuqs';
 import posthog from 'posthog-js';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import InterviewCompleted from '~/app/(interview)/interview/_components/InterviewCompleted';
 import { env } from '~/env.js';
 import { POSTHOG_APP_NAME } from '~/fresco.config';
 
@@ -68,14 +69,22 @@ export default function InterviewClient({
     if (!response.ok) throw new Error('Sync failed');
   }, []);
 
+  const [finished, setFinished] = useState(false);
+
   const onFinish = useCallback<FinishHandler>(
     async (id, signal) => {
       const response = await fetch(`/api/interviews/${id}/finish`, {
         method: 'POST',
         signal,
       });
-      if (!response.ok) throw new Error('Failed to finish interview');
-      router.push('/interview/finished');
+
+      if (!response.ok) {
+        throw new Error('Your interview could not be submitted.');
+      }
+
+      setFinished(true);
+
+      router.replace('/interview/finished');
     },
     [router],
   );
@@ -100,6 +109,10 @@ export default function InterviewClient({
     }),
     [installationId],
   );
+
+  if (finished) {
+    return <InterviewCompleted />;
+  }
 
   return (
     <Shell

--- a/app/(interview)/interview/[interviewId]/InterviewClient.tsx
+++ b/app/(interview)/interview/[interviewId]/InterviewClient.tsx
@@ -76,6 +76,7 @@ export default function InterviewClient({
       const response = await fetch(`/api/interviews/${id}/finish`, {
         method: 'POST',
         signal,
+        keepalive: true,
       });
 
       if (!response.ok) {

--- a/app/(interview)/interview/_components/InterviewCompleted.tsx
+++ b/app/(interview)/interview/_components/InterviewCompleted.tsx
@@ -1,0 +1,14 @@
+import { BadgeCheck } from 'lucide-react';
+import Surface from '@codaco/fresco-ui/layout/Surface';
+import Heading from '@codaco/fresco-ui/typography/Heading';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+
+export default function InterviewCompleted() {
+  return (
+    <Surface className="flex h-screen flex-col items-center justify-center">
+      <BadgeCheck className="text-sea-green mb-4 size-12" />
+      <Heading level="h1">Thank you for participating!</Heading>
+      <Paragraph>Your interview has been successfully completed.</Paragraph>
+    </Surface>
+  );
+}

--- a/app/(interview)/interview/finished/page.tsx
+++ b/app/(interview)/interview/finished/page.tsx
@@ -1,14 +1,5 @@
-import { BadgeCheck } from 'lucide-react';
-import Surface from '@codaco/fresco-ui/layout/Surface';
-import Heading from '@codaco/fresco-ui/typography/Heading';
-import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import InterviewCompleted from '~/app/(interview)/interview/_components/InterviewCompleted';
 
-export default function InterviewCompleted() {
-  return (
-    <Surface className="flex h-screen flex-col items-center justify-center">
-      <BadgeCheck className="text-sea-green mb-4 size-12" />
-      <Heading level="h1">Thank you for participating!</Heading>
-      <Paragraph>Your interview has been successfully completed.</Paragraph>
-    </Surface>
-  );
+export default function InterviewCompletedPage() {
+  return <InterviewCompleted />;
 }


### PR DESCRIPTION
## Problem
On slow connections there's a delay between clicking "Finish Interview" in the dialog and being redirected to /finished. It appears as if the interview wasn't finished, so participants click "Finish" again, see the confirm dialog a second time, and submit a duplicate finish request.

## Cause
`onFinish` did `fetch` → `router.push` and then resolved. App Router navigation is server-driven, so `router.push` returns well before the destination paints. The interview package closes its confirm dialog as soon as `onFinish` resolves, which left the Finish screen mounted and clickable for the whole navigation.

## Fix
Switch to the completion screen on client state instead of waiting for navigation. `onFinish` sets `finished` as its last step, and the component returns `<InterviewCompleted />` when set — unmounting `Shell`, so the Finish screen can't be shown or clicked again.

`router.replace` is kept but is no longer load-bearing; it only tidies the URL, and `replace` rather than `push` keeps back from returning to the interview.

Failed requests still reject, so the dialog stays open and retry works. Dismissing the dialog mid-request aborts and never reaches `setFinished`, leaving the Finish screen usable.

`InterviewCompleted` is extracted from the /finished route into a shared component so the inline and routed renders can't drift.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-interview completion screen confirming successful submission.
  - Completion now displays immediately after finishing, with a clear thank-you message and confirmation icon.
  - Added consistent completion-screen presentation across the interview flow.

- **Bug Fixes**
  - Improved submission failure handling by displaying an error when completion cannot be recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->